### PR TITLE
Correction de la recherche de traductions

### DIFF
--- a/layouts/partials/footer/footer-simple.html
+++ b/layouts/partials/footer/footer-simple.html
@@ -6,7 +6,7 @@
     {{ partial "footer/site.html" }}
   </div>
 </div>
-{{ partial "footer/i18n.html" }}
+{{ partial "footer/i18n.html" . }}
 <div class="container">
   <div class="footer-social">
     {{ partial "footer/social.html" }}

--- a/layouts/partials/footer/i18n.html
+++ b/layouts/partials/footer/i18n.html
@@ -1,4 +1,5 @@
 {{ $page := . }}
+{{ $pageWithTranslations := $page.Translations | append $page }}
 {{ $siteLang := "" }}
 {{ $url := "" }}
 {{ if gt (len site.Languages) 1 }}
@@ -9,7 +10,7 @@
         {{ range site.Languages }}
           {{ $siteLang := . }}
           {{ $url = printf "/%s/" .Lang }}
-          {{ range $page.Translations }}
+          {{ range $pageWithTranslations }}
             {{ if eq .Lang $siteLang.Lang }}
               {{ $url = .Permalink }}
             {{ end }}


### PR DESCRIPTION
Rajout du contexte en paramètre de l'appel à `footer/i18n`.

On ajoute également la page elle-même à la liste des traductions afin que sur la page FR, le lien FR renvoie sur la même page, et non pas l'accueil