### PR TITLE
fixed persons block

### DIFF
--- a/assets/sass/_theme/blocks/persons.sass
+++ b/assets/sass/_theme/blocks/persons.sass
@@ -4,7 +4,6 @@
     gap: $spacing1
     .avatar
         margin-right: 0
-        // order: 1
         width: col(3)
     .description
         margin-top: 0

--- a/assets/sass/_theme/blocks/persons.sass
+++ b/assets/sass/_theme/blocks/persons.sass
@@ -4,9 +4,9 @@
     gap: $spacing1
     .avatar
         margin-right: 0
-        width: col(3)
+        width: col(4)
     .description
-        margin-top: 0
+        margin-top: $spacing1
         text-align: left
 
 .block-persons

--- a/assets/sass/_theme/blocks/persons.sass
+++ b/assets/sass/_theme/blocks/persons.sass
@@ -1,55 +1,41 @@
 @mixin person-avatar-end
-    justify-content: space-between
+    display: flex
+    flex-direction: row
     gap: $spacing1
     .avatar
         margin-right: 0
-        order: 1
+        // order: 1
         width: col(3)
     .description
         margin-top: 0
+        text-align: left
 
 .block-persons
+    article
+        .description
+            margin-top: $spacing1
     @include in-page-with-sidebar
-        &:not(.block-with-long-text)
-            .persons
-                .person
-                    // @include person-avatar-end
         .persons
-            @include grid(1, sm)
+            @include grid(1, desktop)
             row-gap: $spacing0
-            @include media-breakpoint-between(desktop, xl)
-                .person
-                    @include person-avatar-end
+            @include media-breakpoint-up(xxl)
+                @include grid(2)
+                article
+                    .avatar
+                        width: col(1.5, 4)
+                    .description
+                        margin-top: $spacing0
         article
             flex-direction: row
-            gap: $grid-gutter
-            .avatar
-                @include media-breakpoint-up(md)
-                    width: col(2, 8)
-            .description
-                margin-top: $spacing1
-        &.block-with-long-text
-            .person
-                gap: $grid-gutter
-                .description
-                    flex: 1
-                    margin-top: 0
+            gap: $spacing1
+            @include media-breakpoint-up(md)
                 .avatar
                     width: col(2, 8)
-                @include media-breakpoint-up(xl)
-                    flex-direction: row-reverse
     @include in-page-without-sidebar
         .top .description
             max-width: col(8)
         &.block-with-long-text
-            .person
-                flex-direction: row
-                gap: $grid-gutter
-                .description
-                    flex: 1
-                    text-align: left
-                .avatar
-                    @include media-breakpoint-up(sm)
-                        width: col(3, 12)
-                    @include media-breakpoint-up(xl)
-                        width: col(2, 6)
+            .persons
+                @include grid(2)
+                article
+                    @include person-avatar-end

--- a/assets/sass/_theme/blocks/persons.sass
+++ b/assets/sass/_theme/blocks/persons.sass
@@ -13,7 +13,7 @@
         &:not(.block-with-long-text)
             .persons
                 .person
-                    @include person-avatar-end
+                    // @include person-avatar-end
         .persons
             @include grid(1, sm)
             row-gap: $spacing0
@@ -22,10 +22,10 @@
                     @include person-avatar-end
         article
             flex-direction: row
-            gap: col(1, 8)
+            gap: $grid-gutter
             .avatar
                 @include media-breakpoint-up(md)
-                    width: calc(#{col(1, 4)} + #{$grid-gutter})
+                    width: col(2, 8)
             .description
                 margin-top: $spacing1
         &.block-with-long-text

--- a/assets/sass/_theme/sections/persons.sass
+++ b/assets/sass/_theme/sections/persons.sass
@@ -81,16 +81,10 @@ section.persons,
 div.persons
     @include grid(1)
     @include grid(2, md)
-    @include grid(3, lg)
-    @include grid(5, xl)
+    @include grid(4, lg)
     @include grid(6, xxl)
 
-.block-persons.block-with-long-text 
-    div.persons
-        @include grid(1)
-    @include in-page-without-sidebar
-        div.persons
-            @include grid(2, xl)
+
 
 ol.persons--list
     @include list-reset


### PR DESCRIPTION
J'ai commenté `@include person-avatar-end` dans le cas des `.block-persons:not(.block-with-long-text)` pour que l'affichage se remette avec image à gauche (j'attends ta validation @alexisben pour l'enlever)