### PR TITLE
Link variables

### DIFF
--- a/assets/sass/_theme/_configuration.sass
+++ b/assets/sass/_theme/_configuration.sass
@@ -9,7 +9,6 @@ $color-background: #FFFFFF !default
 $body-color: $color-text !default
 $body-background-color: $color-background !default
 $link-color: $color-text !default
-$link-underline-offset: 0.2em !default
 
 // Grid
 $grid-gutter: px2rem(64) !default
@@ -135,6 +134,12 @@ $quote-size: px2rem(24) !default
 $quote-line-height: 120% !default
 $quote-weight: normal !default
 $quote-style: italic !default
+
+// Link
+$link-underline-offset: 0.2em !default
+$link-underline-thickness: 1px !default
+$link-transition: text-decoration-color .3s ease !default
+$link-unhover-decoration-color-alpha: 0.3 !default
 
 // Buttons
 $btn-font-size-desktop: px2rem(18) !default // TODO

--- a/assets/sass/_theme/_utils.sass
+++ b/assets/sass/_theme/_utils.sass
@@ -56,7 +56,7 @@ $space-unit: 4 !default
         text-decoration-color: transparent
     &:hover
         text-decoration-color: rgba($color, 1)
-        text-decoration-thickness: 1px
+        text-decoration-thickness: $link-underline-thickness
 
 @mixin link-hovered-underline-only
     &:not(:hover)

--- a/assets/sass/_theme/_utils.sass
+++ b/assets/sass/_theme/_utils.sass
@@ -47,11 +47,11 @@ $space-unit: 4 !default
 @mixin link($color: $link-color, $unhover_decorated: true)
     color: $color
     text-decoration-line: underline
-    text-decoration-thickness: 1px
+    text-decoration-thickness: $link-underline-thickness
     text-underline-offset: $link-underline-offset
-    transition: text-decoration-color .3s ease
+    transition: $link-transition
     @if $unhover_decorated
-        text-decoration-color: rgba($color, 0.3)
+        text-decoration-color: rgba($color, $link-unhover-decoration-color-alpha)
     @else 
         text-decoration-color: transparent
     &:hover


### PR DESCRIPTION
Ajouts de nouvelles variables pour styliser le mixin "link" : 

```
$link-underline-offset: 0.2em !default
$link-underline-thickness: 1px !default
$link-transition: text-decoration-color .3s ease !default
$link-unhover-decoration-color-alpha: 0.3 !default
```

Ces variables sont utilisées dans le mixin link : 

```

@mixin link($color: $link-color, $unhover_decorated: true)
    color: $color
    text-decoration-line: underline
    text-decoration-thickness: $link-underline-thickness
    text-underline-offset: $link-underline-offset
    transition: $link-transition
    @if $unhover_decorated
        text-decoration-color: rgba($color, $link-unhover-decoration-color-alpha)
    @else 
        text-decoration-color: transparent
    &:hover
        text-decoration-color: rgba($color, 1)
        text-decoration-thickness: $link-underline-thickness
```