### PR TITLE
fix agenda images (layout list)

### DIFF
--- a/assets/sass/_theme/sections/events.sass
+++ b/assets/sass/_theme/sections/events.sass
@@ -147,7 +147,6 @@
                         margin-bottom: $spacing0
                 .media
                     order: 2
-                    width: col(2)
             @include in-page-without-sidebar
                 &-dates
                     margin-top: 0
@@ -169,7 +168,7 @@
                         grid-column: 0 / 5
                         grid-row: 1 / 4
                 .media
-                    grid-column: 11 / 13
+                    width: col(2)
             @include in-page-with-sidebar
                 @include grid(8)
                 &-content


### PR DESCRIPTION
Issue remontée sur l'IUT Bordeaux Montaigne ([#77](https://github.com/noesya/bordeauxmontaigne-iut/issues/77)) 
→ Conflit entre deux partie du code dans le layout `in-page-with-sidebar`