### PR TITLE
Réparation pour la 0.123.0

### DIFF
--- a/layouts/partials/GetPaginateTitle
+++ b/layouts/partials/GetPaginateTitle
@@ -2,7 +2,7 @@
 {{ $seoTitleSeparator := .separator}}
 {{ $page := i18n "commons.pagination.title" }}
 
-{{if not .context.IsHome }}
+{{if and (not .context.IsHome) (eq .kind "page") }}
     {{ with .context.Paginator }}
         {{ if or .HasPrev .HasNext }}
             {{ $currentPageNumber := .PageNumber}}


### PR DESCRIPTION
Depuis la [release 0.123.0](https://github.com/gohugoio/hugo/releases/tag/v0.123.0), le partial `GetPaginateTitle` ne fonctionne plus. 