### PR TITLE
Réparation des exclusions de recherche

### DIFF
--- a/bin/osuny.js
+++ b/bin/osuny.js
@@ -29,10 +29,10 @@ let pagefindExclude = `
     .diplomas__taxonomy, .block-diplomas,
     .events__section, .block-agenda,
     .organizations__section, .block-organizations,
-    .pages__section, .block-pages,
+    .block-pages,
     .persons__section, .block-persons,
     .posts__section, .block-posts, .post-sidebar,
-    .programs__section, .block-programs,
+    .block-programs,
     .researchers__term,
     .teachers__term
     `;


### PR DESCRIPTION
Les pages et formations (`programs`) ne distinguent pas les index des objets avec leur bodyclass, il ne faut donc pas les exclure.
Il faut aussi ajouter les nouveaux blocs de listes.