### PR TITLE
Gestion du scroll dans la recherche

### DIFF
--- a/assets/js/theme/design-system/search.js
+++ b/assets/js/theme/design-system/search.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-undef */
 import { focusTrap } from '../utils/focus-trap';
 
+const CLASSES = {
+    modalOpened: 'has-modal-opened'
+};
+
 class Search {
     constructor (container) {
         this.state = {
@@ -125,6 +129,9 @@ class Search {
         this.state.isOpened = open;
         this.element.setAttribute('aria-hidden', !this.state.isOpened);
         this.button.setAttribute('aria-expanded', this.state.isOpened);
+
+        const classAction = this.state.isOpened ? 'add' : 'remove';
+        document.documentElement.classList[classAction](CLASSES.modalOpened);
 
         if (open) {
             this.input = this.element.querySelector('input');

--- a/assets/sass/_theme/design-system/header.sass
+++ b/assets/sass/_theme/design-system/header.sass
@@ -34,7 +34,7 @@ header#document-header
     &.is-sticky
         .pagefind-ui__toggle
             color: $header-sticky-color
-    html.is-scrolling-down:not(.has-menu-opened) &
+    html.is-scrolling-down:not(.has-menu-opened, .has-modal-opened) &
         @include media-breakpoint-down(desktop)
             transform: translateY(-100%)
         @include media-breakpoint-up(desktop)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On avait un effet super étrange (visible sur cids/mids), la recherche remontait quand on quittait le survol du container #search, car le style du menu scrollant s'appliquait.

J'ai utilisé la même class que pour `Modal`, mais dans l'idéal il faudra factoriser search pour en faire une modale.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱