### PR TITLE
Correction d'une div vide pour les taxonomies

### DIFF
--- a/layouts/organizations/single.html
+++ b/layouts/organizations/single.html
@@ -20,9 +20,11 @@
             ) }}
         {{ end }}
 
-        <div class="taxonomies-container">
-          {{ partial "taxonomies/single-list.html" . }}
-        </div>
+        {{ if .Params.taxonomies }}
+          <div class="taxonomies-container">
+            {{ partial "taxonomies/single-list.html" . }}
+          </div>
+        {{ end }}
 
         {{ partial "commons/contact-details.html" . }}
 

--- a/layouts/pages/list.html
+++ b/layouts/pages/list.html
@@ -13,7 +13,7 @@
         "block_wrapped" true
       ) }}
 
-    {{ if eq site.Params.pages.single.taxonomies.position "content" }}
+    {{ if and .Params.taxonomies (eq site.Params.pages.single.taxonomies.position "content") }}
       <div class="container taxonomies-container">
         {{ partial "taxonomies/single-list.html" . }}
       </div>

--- a/layouts/partials/programs/taxonomies.html
+++ b/layouts/partials/programs/taxonomies.html
@@ -1,5 +1,7 @@
-<section>
-  <div class="container taxonomies-container">
-    {{ partial "taxonomies/single-list.html" . }}
-  </div>
-</section>
+{{ if .Params.taxonomies }}
+  <section>
+    <div class="container taxonomies-container">
+      {{ partial "taxonomies/single-list.html" . }}
+    </div>
+  </section>
+{{ end }}

--- a/layouts/persons/single.html
+++ b/layouts/persons/single.html
@@ -74,7 +74,7 @@
         </div>
       {{ end }}
 
-      {{ if eq site.Params.persons.single.taxonomies.position "content" }}
+      {{ if and .Params.taxonomies (eq site.Params.persons.single.taxonomies.position "content") }}
         <div class="taxonomies-container">
           {{ partial "taxonomies/single-list.html" . }}
         </div>

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -6,9 +6,11 @@
     <meta itemprop="url" content="{{ .Permalink }}">
     {{ with .Params.summary }}<meta itemprop="description" content="{{ . | safeHTML }}">{{ end }}
     
-    <div class="container taxonomies-container">
-      {{ partial "taxonomies/single-list.html" . }}
-    </div>
+    {{ if .Params.taxonomies }}
+      <div class="container taxonomies-container">
+        {{ partial "taxonomies/single-list.html" . }}
+      </div>
+    {{ end }}
 
     {{ partial "projects/summary.html" (dict
         "context" .


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ne pas créer de div vide s'il n'y a pas de taxonomie sur l'objet.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
