### PR TITLE
Bloc personnes : pb de compilation dû à un ancien path (layout list)

### DIFF
--- a/layouts/partials/blocks/templates/persons.html
+++ b/layouts/partials/blocks/templates/persons.html
@@ -33,7 +33,7 @@
         {{ partial "blocks/top.html" $block.top }}
 
         {{ if eq .layout "list" }}
-          {{ partial "blocks/templates/persons/partials/list.html" (dict
+          {{ partial "persons/partials/layouts/list/list.html" (dict
               "options" $options
               "block" $block
             )}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Un path a été oublié avec le lien de l'ancien layout lors de la migration des fichiers de la pré-v8.
Ça concerne le layout liste du bloc personnes.

## URL de test du site (optionnel)

`http://localhost:1314/etudes-professionnalisation/`