### PR TITLE
Bloc agenda: afficher l'événement parent 

### DIFF
--- a/assets/sass/_theme/sections/events/item.sass
+++ b/assets/sass/_theme/sections/events/item.sass
@@ -40,6 +40,7 @@
                 margin-right: space()
     .event-parent
         @include meta
+        order: -1
     .media
         &:empty
             display: none

--- a/layouts/partials/events/partials/event/parent.html
+++ b/layouts/partials/events/partials/event/parent.html
@@ -1,5 +1,5 @@
 {{ with .Params.parent }}
   {{ with site.GetPage .path }}
-    <p class="event-parent">{{ i18n "events.part_of" }} : {{ .Title | safeHTML }}</p>
+    <p class="event-parent">{{ .Title | safeHTML }}</p>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Affichage de l'événement parent dans les blocs agenda. Peut-être ajouter l'option de l'afficher / masquer en admin ?
@arnaudlevy @SebouChu 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots


<img width="464" alt="image" src="https://github.com/user-attachments/assets/12427ea9-4418-4e85-966d-6d8d5ba6ab2c" />

<img width="951" alt="image" src="https://github.com/user-attachments/assets/748dac6d-ecfa-4679-ad5b-53518b3920a9" />

<img width="956" alt="image" src="https://github.com/user-attachments/assets/8b038af0-9add-41bb-86a9-4920272b93ff" />


