### PR TITLE
Mise à jour du sélecteur de titre pour la `toc`

### DIFF
--- a/assets/js/theme/design-system/toc.js
+++ b/assets/js/theme/design-system/toc.js
@@ -14,7 +14,7 @@ class TableOfContents {
         this.content = this.element.querySelector('.toc-content');
         this.nav = this.element.querySelector('.toc');
         this.links = this.element.querySelectorAll('a');
-        this.sections = document.querySelectorAll('.heading[id]');
+        this.sections = document.querySelectorAll('main .heading[id]');
         // TODO : handle sublinks update in toc 
         this.ctaTitle = document.querySelector('.toc-cta-title span');
         this.togglers = document.querySelectorAll('.toc-cta button, .toc-container button');
@@ -25,7 +25,6 @@ class TableOfContents {
             isOffcanvas: this.isOffcanvas()
         };
         this.listen();
-
         if (this.state.isOffcanvas) {
             this.element.setAttribute('aria-hidden', true);
         }


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Mettre un sélecteur plus précis sur le toc pour éviter les effets de bord de bloc de titre en dehors du `main`. Comme les blocs de pieds de page, ou les suggestions.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


