### PR TITLE
Renommer la config `single.taxonomies.display`

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -111,12 +111,12 @@ params:
   default:
     index:
       taxonomies:
-        show_name: true
         layout: dropdown # dropdown | inline
+        show_name: true
     single:
       taxonomies:
-        display: true
         position: content
+        show_name: true
     sitemap:
       ignore_children: false
   categories:
@@ -172,8 +172,8 @@ params:
       truncate_description: 200 # Set to 0 to disable truncate
     single:
       taxonomies:
-        display: false
         position: hero
+        show_name: false
       agenda:
         layout: agenda
         options:

--- a/layouts/partials/taxonomies/single-list.html
+++ b/layouts/partials/taxonomies/single-list.html
@@ -1,10 +1,10 @@
 {{ $context := . }}
 {{ $type := .Type }}
 {{ $taxonomies := .Params.taxonomies }}
-{{ $param := (printf "%s.single.taxonomies.display" $type) }}
+{{ $param := (printf "%s.single.taxonomies.show_name" $type) }}
 {{ $display_taxonomies := partial "GetSiteParamWithDefault" (dict 
   "param" $param
-  "default" "default.single.taxonomies.display"
+  "default" "default.single.taxonomies.show_name"
 ) }}
 
 {{ with $taxonomies }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Modification du nom de configuration `single.taxonomies.display` en `single.taxonomies.show_name`. Cela permet d'être homogène avec la configuration de l'index d'une section : `index.taxonomies.show_name`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

Il faut mettre à jour les sites Diapason, Conservatoire et CYU.