### PR TITLE
Hachage cryptographique des sources d'images pour les logos (header et footer)

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -45,6 +45,7 @@ params:
     # footer:
     #   default: "/assets/images/logo.svg"
     #   darkmode: "/assets/images/logo-white.svg"
+    static_path: true # If false, add fingerprint to img path (cache optimisation) - Images should be in `/assets` folder and not `/static/assets`
   menu:
     primary:
       level_1:

--- a/layouts/partials/commons/logo.html
+++ b/layouts/partials/commons/logo.html
@@ -7,13 +7,21 @@
   {{ $file = $logo.default }}
   {{ $file_darkmode = $logo.darkmode }}
 {{ end }}
+{{ $static_src := site.Params.logo.static_src }}
 
 <a class="logo {{- if $file_darkmode }} with-darkmode {{ end -}}" href="{{ site.Home.Permalink }}" title="{{ i18n "commons.index" (dict "Title" site.Title )}}">
   {{ if $file }}
-    {{ $fileDimensions := partial "GetImageDimensions" (dict "context" . "file" $file "static" true) }}
+    {{ $fileDimensions := partial "GetImageDimensions" (dict "context" . "file" $file "static" $static_src) }}
+    {{ if not $static_src }}
+      {{ $file = (resources.Get (trim $file "/assets") | fingerprint).RelPermalink }}
+    {{ end }}
     <img src="{{ $file }}" alt="{{ site.Title }}" height="{{ index $fileDimensions 1 }}" width="{{ index $fileDimensions 0 }}">
+
     {{ if $file_darkmode }}
-      {{ $fileDimensions := partial "GetImageDimensions" (dict "context" . "file" $file_darkmode "static" true) }}
+      {{ $fileDimensions := partial "GetImageDimensions" (dict "context" . "file" $file_darkmode "static" $static_src) }}
+      {{ if not $static_src }}
+        {{ $file_darkmode = (resources.Get (trim $file_darkmode "/assets") | fingerprint).RelPermalink }}
+      {{ end }}
       <img class="logo-darkmode" src="{{ $file_darkmode }}" alt="{{ site.Title }}" height="{{ index $fileDimensions 1 }}" width="{{ index $fileDimensions 0 }}">
     {{ end }}
   {{ else }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description
Via la config, permettre d'ajouter un "hachage cryptographique" aux src des images de logo pour avoir un "cache-buster" dans le nom de fichier. Ainsi, si le cache côté client est fixé avec une valeur d'un an par exemple, cela évite des problèmes côté utilisateur en cas de mise à jour.

Pour que ce changement soit appliqué, il faut activé la config params/logo/static et déplacer les fichiers des logos dans le dossier assets (et non static/assets) 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
https://github.com/osunyorg/theme/issues/1118


## URL de test sur example.osuny.org
Toutes les pages (header et footer)
