### PR TITLE
Ajustement de la taille desktop des images d'un bloc personnes

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -519,7 +519,7 @@ params:
         grid:
           mobile:   90
           tablet:   220
-          desktop:  150
+          desktop:  245
         large:
           mobile:   400
           tablet:   360


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Diminution de la qualité des images du bloc personne en full width sur grand écran avec la nouvelle grille (2 par 2).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1165

## URL de test sur example.osuny.org

`blocks/blocs-de-liste/organigramme/`

## URL de test du site Sacha André blog

Accueil

## Screenshots

<img width="1898" height="644" alt="Capture d’écran 2025-07-18 à 17 09 32" src="https://github.com/user-attachments/assets/24248fef-3169-49e2-b992-d165e42e63fc" />
<img width="1920" height="645" alt="Capture d’écran 2025-07-18 à 17 10 22" src="https://github.com/user-attachments/assets/3988cc61-cbda-4a68-8041-51f6b4732e04" />

<img width="1919" height="793" alt="Capture d’écran 2025-07-18 à 17 13 25" src="https://github.com/user-attachments/assets/e66346d6-0ff4-4df9-9cd0-ed88839c498b" />
