### PR TITLE
Bloc Papiers : utiliser le `.path`

### DIFF
--- a/layouts/partials/blocks/templates/papers.html
+++ b/layouts/partials/blocks/templates/papers.html
@@ -9,13 +9,13 @@
       <div class="block-content">
         {{ partial "blocks/top.html" $block.top }}
         <div class="papers">
-          {{ range $paper := .papers -}}
-            {{ with site.GetPage (printf "/papers/%s" $paper) }}
+          {{ range .papers -}}
+            {{ with site.GetPage .path }}
               {{ partial "papers/partials/paper.html" (dict 
                   "paper" .
                   "actions" false
                   "heading_level" $block.ranks.children
-              )}}
+                )}}
             {{ end }}
           {{ end}}
         </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Alignement des données des blocs papiers : utiliser le `.path` de la collection `papers`. 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
