### PR TITLE
Suppression d'un double attribut rel

### DIFF
--- a/layouts/partials/blocks/templates/license.html
+++ b/layouts/partials/blocks/templates/license.html
@@ -10,7 +10,7 @@
           <div class="license">
             {{ $file := (printf "/assets/images/blocks/license/%s.svg" .identifier ) }}
             {{ $label := i18n (printf "blocks.licenses.labels.%s" .identifier) }}
-            <a rel="license" href="{{ .url }}" title="{{ i18n "commons.link.blank_aria" (dict "Title" $label) }}" target="_blank" rel="noopener">
+            <a rel="license noopener" href="{{ .url }}" title="{{ i18n "commons.link.blank_aria" (dict "Title" $label) }}" target="_blank">
               <img src="{{ $file }}" alt="{{ $label }}">
             </a>
           </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Les blocs de license ont un lien vers la license qui a 2 attributs rel, 1 avec license et l'autre avec noopener. On les fusionne.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


