### PR TITLE
Correction du schema des organisations

### DIFF
--- a/layouts/partials/organizations/partials/organization.html
+++ b/layouts/partials/organizations/partials/organization.html
@@ -4,13 +4,13 @@
 {{ $heading_level := .heading_level | default 2 }}
 {{ $heading_tag := partial "GetHeadingTag" (dict 
     "level" $heading_level
-    "attributes" "class='organization-title'"
+    "attributes" "class='organization-title' itemprop='name'"
 )}}
 {{ $with_geolocation := .with_geolocation | default false }}
 
 {{ with $organization }}
   {{ $title := partial "PrepareHTML" .Title }}
-  <article class="organization"
+  <article class="organization" itemscope itemtype="https://schema.org/Organization"
     {{ if $with_geolocation }}
       {{ with .Params.contact_details.postal_address.geolocation }}
         data-title="{{ $title }}" 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Les metadata de schema.org sont incomplète sur les organisations, car seule l'adresse présente un balisage (on ne sait donc pas à quoi elle se réfère).

<img width="957" height="264" alt="Capture d’écran 2025-08-29 à 10 26 29" src="https://github.com/user-attachments/assets/728a4e50-3349-456c-baa5-414f9031f8bf" />

État du schema avec cette PR : 
<img width="955" height="347" alt="Capture d’écran 2025-08-29 à 10 26 11" src="https://github.com/user-attachments/assets/d6173dc0-3e2f-46e2-8598-a08a79ad07ba" />

Ajouter le logo est un peu plus complexe, car il faut gérer le fait qu'on utilise parfois un logo, parfois une image d'illustration. Peut-être qu'on peut améliorer le partial d'image, mais il me semble que c'est un autre chantier.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence W3C

https://w3c.noesya.coop/reports/05a32612-acf5-4bcd-881b-c795d9e4fbd3

## URL de test sur example.osuny.org

http://localhost:1313/fr/blocks/blocs-de-liste/partenaires/