### PR TITLE
Ajouter la prise en compte de l'image de partage d'une page aux metadonnées

### DIFF
--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -17,12 +17,12 @@
 {{- $ogImage := "" -}}
 {{- $twitterImage := "" -}}
 {{- $pagefindImage := "" -}}
-{{- if index site.Data.website.default "shared_image" -}}
-  {{- $sharedImage = partial "GetMedia" (index site.Data.website.default.shared_image "id") -}}
+{{- with index site.Data.website.default "shared_image" -}}
+  {{- $sharedImage = partial "GetMedia" (index . "id") -}}
 {{- end -}}
-{{ with or .Params.shared_image .Params.image }}
+{{- with or .Params.shared_image .Params.image }}
   {{- $sharedImage = partial "GetMedia" .id -}}
-{{ end }}
+{{ end -}}
 
 {{- with $sharedImage -}}
   {{- $ogImage = partial "GetImageUrl" (dict


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Sur le site https://mecapop.huma-num.fr/fr/, l'image de partage de la version française n'est pas la bonne.

C'est parce qu'on utilisait uniquement : 
1. L'image de la page
2. L'image de partage par défaut

Donc jamais l'image de partage propre à la page.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site Mecapop

Accueil + `http://localhost:1313/fr/cordels/`

## Screenshots


