### PR TITLE
Ajustement des contenus sticky dans les sidebars

### DIFF
--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -115,23 +115,11 @@
 
     // Only desktop and in page with sidebar
     @include in-page-with-sidebar
+        @include sidebar
         margin-left: grid-external-space()
         pointer-events: none
-        top: 0
-        left: 0
-        margin-top: 0
-        height: 100%
-        position: absolute
         width: columns(4)
         z-index: $zindex-toc
-        .toc-content
-            overflow-y: auto
-            max-height: calc(100vh - var(--header-height))
-            padding-bottom: $spacing-4
-            pointer-events: auto
-            @include sticky($spacing-3)
-            html.is-scrolling-down &
-                max-height: calc(100vh - #{$spacing-3})
         .toc-title
             color: var(--color-text-alt)
         button

--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -56,10 +56,20 @@
         position: absolute
         width: columns(4)
         & > div
-            @include sticky($spacing-3)
+            display: flex
+            flex-direction: column
+            height: 100%
+            position: relative
         .toc-container
-            position: static
             margin-left: 0
+        .toc-content
+            @include sticky
+            max-height: 100vh
+            overflow: auto
+            pointer-events: auto
+        html.is-scrolling-down &
+            [class$="-title"]
+                padding-top: $spacing-3
         &:has(aside)
             .toc-container
                 border-top: var(--border-width) solid var(--color-border)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Seule la toc doit être sticky.

(todo: padding du title)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/951

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/tous-les-blocks`

## URL de test du site (optionnel)



## Screenshots


