### PR TITLE
Alertes : ajustement du `role` du titre

### DIFF
--- a/layouts/partials/commons/alerts/alert.html
+++ b/layouts/partials/commons/alerts/alert.html
@@ -1,7 +1,7 @@
 <div class="alert alert--{{ .level }}">
   <div class="container">
     <div class="alert__content">
-      <p class="alert__title" role="title" aria-level="1">{{ .title | safeHTML }}</p>
+      <p class="alert__title" role="heading" aria-level="1">{{ .title | safeHTML }}</p>
       <div class="rich-text">
         {{ .content | safeHTML }}
       </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Le rôle "title" en aria n'existe pas, c'est `heading` : https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://w3c.noesya.coop/reports/0f3f19b6-acc2-440e-840a-d1f640b40d2d