### PR TITLE
Correction de l'espace du `hero` en présence d'une alerte

### DIFF
--- a/assets/sass/_theme/design-system/alerts.sass
+++ b/assets/sass/_theme/design-system/alerts.sass
@@ -1,6 +1,6 @@
 .alerts
     padding-top: var(--header-height)
-    + main
+    ~ main
         > .hero
             padding-top: 0
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Retirer l'espace haut (`padding-top`) du `hero` lorsqu'une alerte est présente : 

Avant : 

<img width="2048" height="967" alt="image" src="https://github.com/user-attachments/assets/2fdf90e5-a4fd-4b54-9568-91e9d510d797" />

Après : 

<img width="2048" height="1023" alt="image" src="https://github.com/user-attachments/assets/cb628660-945f-4eee-a4a2-17bc8c4c0abe" />


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


