### PR TITLE
Correction du double clic sur le dropdown i18n dans le menu principal

### DIFF
--- a/layouts/partials/commons/i18n.html
+++ b/layouts/partials/commons/i18n.html
@@ -5,7 +5,7 @@
 {{ $position := .position }}
 {{ $dropdown_class := "dropdown-menu dropdown-languages" }}
 
-{{ if ne $position "primary" }}
+{{ if eq $position "footer" }}
   {{ $dropdown_class = printf "%s extendable" $dropdown_class }}
 {{ end }}
 


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dû a un conflit entre le comportement des `extendables` et des `dropdown` du menu, il fallait cliquer deux fois pour ouvrir le menu des langues dans la navigation principale ou dans le sur-menu (`upper-menu`).
À l'idéal il faut factoriser les comportements des dropdown du menu afin qu'il s'appuie sur des `extendables`. Ce travail fait partie de la refonte du javascript en es5. 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1108

