### PR TITLE
Gestion de l'espace vertical quand le hero est suivi d'un bloc coloré

### DIFF
--- a/assets/sass/_theme/blocks/base.sass
+++ b/assets/sass/_theme/blocks/base.sass
@@ -33,7 +33,6 @@ main
 body.full-width
     .hero + .document-content
         > div:first-child.blocks
-            background: red
             #{$backgrounded_blocks}
                 &:first-child
                     margin-top: -$spacing-3


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans le cas où des blocs colorés, en pleine largeur, suivent directement le hero, une marge est ajoutée (le seul comportement spécifique à ces blocs pour le hero concerne le padding-top, autrement il n'y a que dans le footer qu'ils sont collés).

<img width="1470" height="798" alt="Capture d’écran 2025-10-15 à 09 51 40" src="https://github.com/user-attachments/assets/6d38f33e-a618-49db-a92f-85fa9b95424d" />

### Remarques
Cibler `.hero + .document-content` permet d'éviter les effets de bord avec une marge négative qui viendrait remonter les blocs sur le fil d'ariane ou les taxonomies. 

Aussi, petite factorisation de $backgrounded_blocks étant donné qu'on a des class uniformes : 
```
$backgrounded_blocks:  [class*="--accent_background"], [class*="--alt_background"], ...
```

⚠️ Point d'attention sur les comportements des marges en fonction des formats d'image du hero.

nb1 : les espacements verticaux avec un fil d'ariane sous le hero sont étranges.
nb2 : peut-être ajouter une variable à la marge mobile/desktop du hero, comme c'est utilisé à 2 endroits ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`/blocks/blocks-narratifs/appels-a-action/`
`/blocks/blocks-de-base/chapitres/`
`/blocks/blocks-narratifs/frise/`

## URL de test du site [Support Osuny](https://support.osuny.org/)Accueil

Accueil

## Screenshots

<img width="1470" height="798" alt="Capture d’écran 2025-10-15 à 09 51 58" src="https://github.com/user-attachments/assets/b7784112-88c5-402a-943e-47260115743f" />

Pas de problème avec un fil d'ariane : 

<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/d7953e34-5156-402c-a960-8451e378b98e" />

Ni en mobile : 
<img width="395" height="684" alt="Capture d’écran 2025-10-15 à 09 52 09" src="https://github.com/user-attachments/assets/4b70401b-a2c1-4a89-9ffe-44f47ec429e6" />

### Test sur example avec différents contextes
<img width="1469" height="797" alt="Capture d’écran 2025-10-15 à 10 13 37" src="https://github.com/user-attachments/assets/139ed15d-f69b-4e51-b9fa-eb382cdcd776" />
<img width="1065" height="654" alt="Capture d’écran 2025-10-15 à 10 02 40" src="https://github.com/user-attachments/assets/204d3863-6dbd-4706-80a5-c3cd9b42dcf7" />

#### Cas particuliers : fil d'ariane ou taxonomies à la suite du hero
<img width="1468" height="797" alt="Capture d’écran 2025-10-15 à 10 13 18" src="https://github.com/user-attachments/assets/dd2a9c7d-b48f-4191-8624-5c8c9e0261ca" />
<img width="1068" height="750" alt="Capture d’écran 2025-10-15 à 10 02 26" src="https://github.com/user-attachments/assets/61e83c14-8e7e-417c-acc2-e1e04c56f87e" />

#### Mobile
<img width="393" height="697" alt="Capture d’écran 2025-10-15 à 10 15 18" src="https://github.com/user-attachments/assets/40e27070-b4d7-4806-bf58-f3da1707fc55" />