### PR TITLE
Mobile volumes list spacing

### DIFF
--- a/assets/sass/_theme/sections/volumes.sass
+++ b/assets/sass/_theme/sections/volumes.sass
@@ -9,6 +9,7 @@
     @include grid(2, md)
     @include grid(3, lg)
     @include media-breakpoint-down(desktop)
+        // remove that when v8 add lists everywhere
         > div + div,
         > .volume + .volume
             margin-top: $spacing-4


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Les volumes présentent un pb d'alignement (qui sera réparé dans la [v8](https://github.com/osunyorg/theme/pull/1216) et la gestion des listes) en mobile.

<img width="373" height="662" alt="Capture d’écran 2025-10-27 à 15 20 23" src="https://github.com/user-attachments/assets/d80aa5db-3755-4c9f-a6c0-324769d220e2" />

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example journal

http://localhost:1313/
http://localhost:1313/volumes/

## URL de test du site Degrowth Journal

http://localhost:1313/volumes/

## Screenshots

<img width="391" height="686" alt="Capture d’écran 2025-10-27 à 15 18 22" src="https://github.com/user-attachments/assets/3471dada-ada9-42a5-8e89-c18c5905bf49" />