### PR TITLE
Ajout d'une config pour paramétrer les images visibles dans pagefind

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -463,6 +463,8 @@ params:
         arrows: true
         progression: true
   image_sizes:
+    _default:
+      pagefind: "244"
     design_system:
       lightbox:
         disabled: false

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -36,7 +36,7 @@
         ) -}}
   {{- $pagefindImage = partial "GetImageUrl" (dict
           "media" .
-          "size" "244"
+          "size" site.Params.image_sizes._default.pagefind
         ) -}}
 {{- end -}}
 {{- $seoUrl := .Permalink -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Sur GL, les images prennent plus de place et doivent donc avoir une taille supérieure (555).

Config sur le modèle de la v8 : 
```yaml
image_sizes:
  _default:
      pagefind: "244"
````

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant :
<img width="1920" height="956" alt="Capture d’écran 2025-11-03 à 11 40 31" src="https://github.com/user-attachments/assets/98c176e2-15b2-4a44-9556-6a04f5388460" />


Après :
<img width="1918" height="954" alt="Capture d’écran 2025-11-03 à 11 39 36" src="https://github.com/user-attachments/assets/d5651251-9fbe-47a5-8c65-d315d273d9d5" />

