### PR TITLE
Ajustement de l'icône du player

### DIFF
--- a/assets/sass/_theme/design-system/lazy-player.sass
+++ b/assets/sass/_theme/design-system/lazy-player.sass
@@ -45,5 +45,5 @@
             height: space(16)
             width: space(16)
             &::before
-                font-size: calc(#{pxToRem(20)} - var(--border-width))
+                font-size: pxToRem(20)
                 padding-left: pxToRem(4)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Ajustement de l'icône du player vidéo : actuellement il supporte mal la modification de la variable de l'épaisseur des bordures.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

<img width="281" height="245" alt="image" src="https://github.com/user-attachments/assets/675c7654-9103-40e6-b250-8f560cbac435" />


Après : 

<img width="279" height="201" alt="image" src="https://github.com/user-attachments/assets/4b3bf1be-f07a-45e9-ab69-f419de8752ad" />

