### PR TITLE
Espace vertical du premier bloc : variante avec sidebar

### DIFF
--- a/assets/sass/_theme/blocks/base.sass
+++ b/assets/sass/_theme/blocks/base.sass
@@ -24,10 +24,13 @@
 $backgrounded_blocks: "[class*="--accent_background"], [class*="--alt_background"], .block-timeline--horizontal, .block-pages--cards"
 main
     .blocks
-        .block:first-child:is(#{$backgrounded_blocks})
-            margin-top: 0
         .block:last-child:is(#{$backgrounded_blocks})
             margin-bottom: 0
+        .block:first-child:is(#{$backgrounded_blocks})
+            @include in-page-without-sidebar
+                margin-top: 0
+            @include media-breakpoint-down(desktop)
+                margin-top: 0
 
 // Following chapters
 .block-chapter

--- a/assets/sass/_theme/blocks/base.sass
+++ b/assets/sass/_theme/blocks/base.sass
@@ -27,10 +27,7 @@ main
         .block:last-child:is(#{$backgrounded_blocks})
             margin-bottom: 0
         .block:first-child:is(#{$backgrounded_blocks})
-            @include in-page-without-sidebar
-                margin-top: 0
-            @include media-breakpoint-down(desktop)
-                margin-top: 0
+            margin-top: 0
 
 // Following chapters
 .block-chapter

--- a/assets/sass/_theme/design-system/hero.sass
+++ b/assets/sass/_theme/design-system/hero.sass
@@ -45,7 +45,6 @@
                 width: 100%
                 height: auto
             @include collapsed-figcaption
-
     .breadcrumb-nav + .content
         padding-top: 0
     .content + .breadcrumb-nav
@@ -55,6 +54,8 @@
             position: relative
             > a
                 @include stretched-link
+    &.has-breadcrumb-hero-end
+        padding-bottom: 0
     @include media-breakpoint-down(desktop)
         .content
             padding-top: 0

--- a/assets/sass/_theme/design-system/layout.sass
+++ b/assets/sass/_theme/design-system/layout.sass
@@ -75,17 +75,14 @@ ol
     > .blocks
         .block:first-child
             margin-top: var(--grid-gutter)
-    
     @include in-page-with-sidebar
         .heading h2, .block .block-content
             padding-left: offset(4)
-    
-    // @include in-page-without-sidebar
-    //     > .blocks
-    //         .block:first-child
-    //             &[class*="--accent_background"],
-    //             &[class*="--alt_background"]
-    //                 margin-top: 0
+    .has-breadcrumb-hero-end + &
+        @include in-page-with-sidebar
+            > .blocks
+                margin-top: var(--grid-gutter)
+
 details
     &:not([open]):hover
         summary::after


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Ajustement de la règle de l'espace au dessus du premier bloc.

Avec une sidebar, la règle excluant le premier bloc avec fond ne doit pas s'appliquer.

<img width="1440" height="567" alt="image" src="https://github.com/user-attachments/assets/b94af7a3-219d-4b08-82f0-f65189892b08" />


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


