### PR TITLE
Plan du site : ignorer les index non rendu

### DIFF
--- a/layouts/pages/sitemap.html
+++ b/layouts/pages/sitemap.html
@@ -44,7 +44,7 @@
         "param" (printf "%s.sitemap.ignore" .Type)
         "default" "default.sitemap.ignore"
       ) }}
-      {{ if and (ne .Type "sitemap") (ne .Type "pages") (not $ignore_section) }}
+      {{ if and (ne .Type "sitemap") (ne .Type "pages") (not $ignore_section) .Permalink }}
         {{ $permalink := .Permalink }}
         <div class="block block-sitemap" id="{{ .Type }}">
           <div class="container">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Enlever les section qui ne sont pas rendue dans le sitemap.

Par exemple si l'index des personnes `content/fr/persons/_index.html` n'est pas rendu (mis en brouillon dans l'admin), il faut ignorer son affichage.

```
build:
  list: always
  publishResources: true
  render: never
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


