### PR TITLE
[A11Y] Retrait du `aria-labelledby` des menu

### DIFF
--- a/layouts/partials/commons/menu-dropdown.html
+++ b/layouts/partials/commons/menu-dropdown.html
@@ -10,7 +10,7 @@
   {{ $class = printf "%s is-titled" $class }}
 {{ end }}
 
-<div class="{{ $class }}" aria-labelledby="dropdown-{{ $slug }}">
+<div class="{{ $class }}">
   {{- with $level_options.title }}
     {{ if .active }}
       <div class="container">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Réparation du problème de conformité W3C sur le nommage de dropdown de menu.
Ça ne pose pas de pb d'enlever ça car l'intitulé du bouton est répété lorsqu'il est `expanded`.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1271