### PR TITLE
Couleur des titres dans les blocs en layout "carte"

### DIFF
--- a/assets/sass/_theme/design-system/layouts/cards.sass
+++ b/assets/sass/_theme/design-system/layouts/cards.sass
@@ -11,6 +11,8 @@
         transition: background $background-duration, color $background-duration
         [class$="-title"]
             @include h3
+            a
+                color: inherit
         [class$="-content"]
             display: flex
             flex-direction: column


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le lien du titre d'un item dans un layout "cartes" ne prenait pas la couleur définie dans le mixin (au contraire du `.more` auquel on passe directement un `@include link($color)` pour imiter un lien).

(problème relevé sur le site de Iris instrument)

Ici, on fait hériter le lien de la couleur de son parent (`$color`).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

- `https://example.osuny.org/fr/blocks/blocs-de-liste/pages/#mise-en-page-cartes`
- `https://example.osuny.org/fr/blocks/blocs-de-liste/les-categories/#layout-cartes`

## URL de test du site Iris instrument

[Le probl](https://irisinstruments.netlify.app/en/)

(fix en overide en attendant)

## Screenshots

### Avec la variable `$block-pages-card-page-color` sur la couleur d'accent 

- **Version en ligne**
<img width="1451" height="781" alt="Capture d’écran 2025-12-02 à 21 17 36" src="https://github.com/user-attachments/assets/a60639e6-79c6-4462-a9d6-5cf685443041" />


- **Version sur la branche**
<img width="1448" height="783" alt="Capture d’écran 2025-12-02 à 21 17 51" src="https://github.com/user-attachments/assets/f784360e-a918-4138-ac22-1fc6f465715c" />

----

### Avec la variable `$layout-cards-item-color` sur la couleur d'accent 

- **Version en ligne**
<img width="1449" height="580" alt="Capture d’écran 2025-12-02 à 21 17 18" src="https://github.com/user-attachments/assets/a6e08643-4e25-4acd-bd44-2ab2e2e9ef73" />


- **Version sur la branche**
<img width="1447" height="581" alt="Capture d’écran 2025-12-02 à 21 17 05" src="https://github.com/user-attachments/assets/bfb889cb-db16-466d-945d-4d404ba9c9e9" />

(le texte grisé est défini pour tout l'item, faudrait-il envisager un `alphaColor` dans ce contexte ?