### PR TITLE
Actualités uniques dans les catégories

### DIFF
--- a/layouts/partials/posts/partials/posts.html
+++ b/layouts/partials/posts/partials/posts.html
@@ -1,14 +1,15 @@
 {{ $layout := site.Params.posts.index.layout }}
 {{ $options := site.Params.posts.index.options }}
+{{ $paginator := .Paginate ( .Pages | uniq ) }}
 
 {{ $list_class := printf "posts posts--%s" $layout }}
 {{ $list_class = printf "%s %s" $list_class (cond $options.image "with-images" "without-images") }}
 <ul class="{{ $list_class }}">
-  {{ if not .Paginator.Pages }}
+  {{ if not $paginator.Pages }}
     {{ $is_term := eq .Kind "term" }}
     <p>{{ i18n (cond $is_term "categories.no_post" "posts.none") }}</p>
   {{ else }}
-    {{ range .Paginator.Pages }}
+    {{ range $paginator.Pages }}
       {{ partial "posts/partials/post.html" (dict 
         "post" .
         "layout" $layout


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Cela répare l'apparition d'actualités dupliquées lorsqu'elles sont catégorisées dans une catégorie et une catégorie fille de cette même catégorie : 

```
posts_categories:
  - "litterature"
  - "litterature/science-fiction"
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
