### PR TITLE
[A11Y] Retrait du `aria-labelledby` du container de la table des matières

### DIFF
--- a/layouts/partials/toc/container.html
+++ b/layouts/partials/toc/container.html
@@ -7,7 +7,7 @@
 {{- if $isTocPresent -}}
   {{- partial "toc/cta" -}}
 
-  <div class="toc-container" aria-hidden="false" aria-labelledby="toc-title">
+  <div class="toc-container" aria-hidden="false">
     <div class="toc-content">
       {{/* TODO : quelle balise pour le titre du toc ? */}}
       <div id="toc-title" class="toc-title" role="heading" aria-level="2">{{ i18n "commons.toc.title" }}</div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Identique à https://github.com/osunyorg/theme/pull/1274

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence W3C

> _The “aria-labelledby” attribute must not be specified on any “div” element unless the element has a “role” value other than “caption”, “code”, “deletion”, “emphasis”, “generic”, “insertion”, “paragraph”, “presentation”, “strong”, “subscript”, or “superscript”._

## URL de test sur example.osuny.org

https://example.osuny.org/fr/exemples/

Le titre est bien restitué et le premier aria-labelledby suffit.