### PR TITLE
Categories : correction href sur span

### DIFF
--- a/layouts/partials/commons/categories.html
+++ b/layouts/partials/commons/categories.html
@@ -17,7 +17,7 @@
         {{ $id := printf "%s-children-list" ( .Slug | anchorize) }}
         {{ $children := partial "GetObjectsFromPathSlice" .Params.children }}
         {{ if and $depth $children }}
-          <span href="{{ .Permalink }}" class="extendable-button" aria-expanded="false" aria-controls="{{ $id }}" role="button" tabindex="0">
+          <span class="extendable-button" aria-expanded="false" aria-controls="{{ $id }}" role="button" tabindex="0">
             {{- safeHTML .Title -}}
           </span>
           <div id="{{ $id }}" class="extendable dropdown" data-extendable-auto-close="true">


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Retirer le href sur le span

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

#1282 
