### PR TITLE
Option des meta d'une single de post

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -358,6 +358,7 @@ params:
     single:
       options:
         authors: true
+        published_at: true
         reading_time: true
         signature: false
         updated_at: true

--- a/layouts/partials/posts/single/post-infos.html
+++ b/layouts/partials/posts/single/post-infos.html
@@ -8,10 +8,12 @@
     {{ end }}
   {{ end }}
 
-  <li>
-    <span>{{ i18n "commons.published_at" }}</span>
-    <time datetime="{{ .Date.Format "2006-01-02T15:04" }}">{{ .Date | time.Format site.Params.posts.date_format }}</time>
-  </li>
+  {{ if site.Params.posts.single.options.published_at }}
+    <li>
+      <span>{{ i18n "commons.published_at" }}</span>
+      <time datetime="{{ .Date.Format "2006-01-02T15:04" }}">{{ .Date | time.Format site.Params.posts.date_format }}</time>
+    </li>
+  {{ end }}
 
   {{ if site.Params.posts.single.options.updated_at }}
     <li>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajoute une option de configuration pour afficher ou masquer la date de publication d'un article.

```
params:
  posts:
     single:
        options:
          authors: true
          published_at: true
          reading_time: true
          signature: false
          updated_at: true
```


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
