### PR TITLE
Correction des duplications des organisations dans les pages de catégories

### DIFF
--- a/layouts/partials/organizations/partials/organizations.html
+++ b/layouts/partials/organizations/partials/organizations.html
@@ -1,12 +1,13 @@
 {{ $options := site.Params.organizations.index.options }}
 {{ $layout := "grid" }}
+{{ $paginator := .Paginate ( .Pages | uniq ) }}
 
-{{ if not .Paginator.Pages }}
+{{ if not $paginator.Pages }}
   {{ $is_term := eq .Kind "term" }}
   <p>{{ i18n (cond $is_term "categories.no_organization" "organizations.none") }}</p>
 {{ else }}
   <ul class="organizations organizations--grid {{- if $options.summary }} with-summaries {{- end }}">
-    {{ range .Paginator.Pages }}
+    {{ range $paginator.Pages }}
       <li>
         {{ partial "organizations/partials/organization.html" (dict
             "organization" .


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les catégories parentes affichaient des organisations dupliquées. On ré-écrit la pagination native d'hugo pour corriger cela.

```
{{ $paginator := .Paginate ( .Pages | uniq ) }}
```


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

<img width="1380" height="701" alt="image" src="https://github.com/user-attachments/assets/4dffb230-632f-4c5a-b0e0-4c84d906e5a1" />

Après : 

<img width="1372" height="686" alt="image" src="https://github.com/user-attachments/assets/4d0e8156-8b6d-4c06-9e81-fff2f689c185" />



