### PR TITLE
Masquer les sous-catégories si les filtres sur les catégories sont présents

### DIFF
--- a/layouts/partials/categories/single.html
+++ b/layouts/partials/categories/single.html
@@ -18,9 +18,10 @@
     "contents" .Params.contents
   ) }}
 
-  {{ with .Params.children }}
-    {{ partial "categories/single/categories.html" . }}
-  {{ end }}
+  {{ partial "categories/single/categories.html" (dict 
+    "categories" .Params.children
+    "context" .
+  ) }}
 
   <div class="container">
     {{ $section_type := strings.TrimSuffix "_categories" .Type }}

--- a/layouts/partials/categories/single/categories.html
+++ b/layouts/partials/categories/single/categories.html
@@ -1,13 +1,22 @@
-{{ $categories := . }}
-<div class="container children-categories">
-  <ul aria-label="{{ i18n "categories.label" }}">
-    {{ range $categories }}
-      {{ $category := site.GetPage .path }}
-      {{ with $category }}
-        <li>
-          <a href="{{ .Permalink }}">{{ .Title }}</a>
-        </li>
+{{ $categories := .categories }}
+{{/*  If categories/taxonomies filters is displayed, do not display category's children list  */}}
+{{ $section := replace .Params.taxonomy "_categories" "" }}
+{{ $is_filters_displayed := partial "GetSiteParamWithDefault" (dict 
+  "param" (printf "%s.categories.taxonomies.display" $section)
+  "default" "categories.single.taxonomies.display"
+) }}
+
+{{ if and $categories (not $is_filters_displayed) }}
+  <div class="container children-categories">
+    <ul aria-label="{{ i18n "categories.label" }}">
+      {{ range $categories }}
+        {{ $category := site.GetPage .path }}
+        {{ with $category }}
+          <li>
+            <a href="{{ .Permalink }}">{{ .Title }}</a>
+          </li>
+        {{ end }}
       {{ end }}
-    {{ end }}
     </ul>
   </div>
+{{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Quand les filtres des catégories / taxonomies sont présents sur les `single` des catégories il faut masquer les sous-catégories.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant : 

Il y a les filtres + les sous-catégories

<img width="1440" height="588" alt="image" src="https://github.com/user-attachments/assets/4c54b1af-f9ee-41b7-8517-87d8bc69d12c" />


Après : 

Si les filtres sont activés, on ne génére pas la liste des sous-catégories

<img width="1192" height="565" alt="image" src="https://github.com/user-attachments/assets/6befb023-c5f5-4e27-83dc-84852266ea52" />
