### PR TITLE
Événements : ajout d'une option pour forcer l'affichage du "En savoir plus"

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -203,6 +203,7 @@ params:
     list:
       time_slots:
         date_format: ":date_long"
+      with_more: false
     # share_links: # Optional
     #   enabled: true
     #   email: false

--- a/layouts/partials/events/partials/event.html
+++ b/layouts/partials/events/partials/event.html
@@ -2,7 +2,7 @@
 {{ $layout := .layout | default "list" }}
 {{ $is_sub_event := .is_sub_event }}
 {{ $is_sup_event := .is_sup_event }}
-{{ $with_more := .with_more }}
+{{ $with_more := .with_more | default site.Params.events.list.with_more }}
 {{ $heading_level := .heading_level | default 3 }}
 
 {{ $index := .index }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout de l'option "with_more" pour les événements. Partout où un événement est listé, il affiche le text "En savoir plus".

Désactivé par défaut.

```
params:
  events:
    list:
      with_more: false
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


