### PR TITLE
Notes : ajustement de la hauteur

### DIFF
--- a/assets/sass/_theme/design-system/notes.sass
+++ b/assets/sass/_theme/design-system/notes.sass
@@ -7,9 +7,8 @@
         cursor: pointer
         display: block
         line-height: inherit
-        margin-bottom: -5px
+        margin-bottom: -0.5em
         min-width: $minimum-accessible-size
-        padding-bottom: 0
         padding-left: $spacing-2
         padding-right: $spacing-2
         text-align: center


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

La note crée une très légère rupture du rythme vertical (2 pixels).
J'ajoute une marge négative en bas pour éviter cet effet, et ne pas interférer avec la hauteur de ligne du texte normal.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://example.osuny.org/fr/blocks/blocks-de-base/chapitres/

https://www.encommuns.net/articles/2025-03-31-prendre-soin-faire-face-a-la-tragedie-des-non-communs/

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots

Incorrect
<img width="1143" height="462" alt="Capture d’écran 2026-01-01 à 10 03 54" src="https://github.com/user-attachments/assets/6a93e13e-8fd5-4190-b01a-fa5d46a028c1" />

Correct (oui, c'est subtil)

<img width="1175" height="412" alt="Capture d’écran 2026-01-01 à 10 05 28" src="https://github.com/user-attachments/assets/31ac18f3-acd4-4bbe-815c-ddf1b2417b69" />
