### PR TITLE
Espacement du "En savoir plus" dans les listes d'événements

### DIFF
--- a/assets/sass/_theme/sections/events/item.sass
+++ b/assets/sass/_theme/sections/events/item.sass
@@ -36,6 +36,8 @@
     .event-parent
         @include meta
         order: -1
+    .more
+        margin-top: $spacing-2
     .media
         &:empty
             display: none


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Avec l'option `with_more: true` dans une liste d'événement, la marge au-dessus du "En savoir plus" ne fonctionnait que pour le layout large (car importante marge) et le layout liste sans catégorie (les catégories n'ont pas le marge inférieure).

<img width="1299" height="944" alt="Capture d’écran 2026-01-08 à 11 46 54" src="https://github.com/user-attachments/assets/39359142-d0a8-4061-9c79-5f011d73766a" />

----

Pour régler ça, on ajoute d'une marge supérieure au `.more`, qui se merge au besoin avec celle de l'élément qui le précède et peut être surchargée pour les besoins d'un layout en particulier (large).

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

https://example.osuny.org/fr/blocks/blocs-de-liste/agenda-1/
https://example.osuny.org/fr/agenda/

## Screenshots

<img width="1917" height="957" alt="Capture d’écran 2026-01-08 à 11 44 48" src="https://github.com/user-attachments/assets/d3625dd3-ed0e-4cf6-b54f-7c97b40eec49" />
<img width="1917" height="955" alt="Capture d’écran 2026-01-08 à 11 45 03" src="https://github.com/user-attachments/assets/dc120600-0afe-4b9e-8aaa-2e9015ccb10c" />
<img width="1917" height="957" alt="Capture d’écran 2026-01-08 à 11 45 19" src="https://github.com/user-attachments/assets/355b6798-3fe0-4653-96c7-d573095d44e0" />
<img width="1918" height="956" alt="Capture d’écran 2026-01-08 à 11 45 29" src="https://github.com/user-attachments/assets/58943f70-f83b-4ea2-90bf-b9c18bd119d2" />
<img width="1277" height="763" alt="Capture d’écran 2026-01-08 à 11 45 38" src="https://github.com/user-attachments/assets/82aeebe4-b5db-45de-a77a-aad7c4566c6a" />
<img width="1917" height="957" alt="image" src="https://github.com/user-attachments/assets/91ec05ac-5eb0-44f3-8a25-c58ea360ae62" />
