### PR TITLE
Formation : affichage du lien d'inscription seul

### DIFF
--- a/layouts/partials/programs/single/admission.html
+++ b/layouts/partials/programs/single/admission.html
@@ -1,4 +1,4 @@
-{{- if or (partial "GetTextFromHTML" .Params.prerequisites) (partial "GetTextFromHTML" .Params.pricing) (partial "GetTextFromHTML" .Params.registration) (partial "GetTextFromHTML" .Params.accessibility) (partial "GetTextFromHTML" .Params.other) -}}
+{{- if or (partial "GetTextFromHTML" .Params.prerequisites) (partial "GetTextFromHTML" .Params.pricing) (partial "GetTextFromHTML" .Params.registration) .Params.registration_url (partial "GetTextFromHTML" .Params.accessibility) (partial "GetTextFromHTML" .Params.other) -}}
 <section id="{{ anchorize (i18n "programs.toc.admission") }}">
   <div class="container">
     <div class="content">

--- a/layouts/partials/programs/single/toc.html
+++ b/layouts/partials/programs/single/toc.html
@@ -13,7 +13,7 @@
 {{ $pricing_initial := partial "GetTextFromHTML" .context.Params.pricing_initial }}
 {{ $pricing_continuing := partial "GetTextFromHTML" .context.Params.pricing_continuing }}
 {{ $pricing_apprenticeship := partial "GetTextFromHTML" .context.Params.pricing_apprenticeship }}
-{{ $registration := partial "GetTextFromHTML" .context.Params.registration }}
+{{ $registration := or (partial "GetTextFromHTML" .context.Params.registration) .context.Params.registration_url }}
 {{ $accessibility := partial "GetTextFromHTML" .context.Params.accessibility }}
 {{ $other := partial "GetTextFromHTML" .context.Params.other }}
 
@@ -56,25 +56,25 @@
           {{- end -}}
         </ol>
     </li>
-    <li>
-      <a {{ partial "AnchorAttribute" (i18n "programs.toc.pedagogy") }}>{{ i18n "programs.toc.pedagogy" }}</a>
-      {{- if or $content $pedagogy $evaluation $teachers }}
-      <ol>
-        {{- if $content -}}
-          <li><a {{ partial "AnchorAttribute" (i18n "programs.content") }}>{{ i18n "programs.content" }}</a></li>
-        {{- end -}}
-        {{- if $pedagogy -}}
-          <li><a {{ partial "AnchorAttribute" (i18n "programs.pedagogy") }}>{{ i18n "programs.pedagogy" }}</a></li>
-        {{- end -}}
-        {{- if $evaluation -}}
-          <li><a {{ partial "AnchorAttribute" (i18n "programs.evaluation") }}>{{ i18n "programs.evaluation" }}</a></li>
-        {{- end -}}
-        {{- if $teachers -}}
-          <li><a {{ partial "AnchorAttribute" (i18n "programs.teachers") }}>{{ i18n "programs.teachers" }}</a></li>
-        {{- end -}}
-      </ol>
-      {{ end -}}
-    </li>
+    {{- if or $content $pedagogy $evaluation $teachers }}
+      <li>
+        <a {{ partial "AnchorAttribute" (i18n "programs.toc.pedagogy") }}>{{ i18n "programs.toc.pedagogy" }}</a>
+        <ol>
+          {{- if $content -}}
+            <li><a {{ partial "AnchorAttribute" (i18n "programs.content") }}>{{ i18n "programs.content" }}</a></li>
+          {{- end -}}
+          {{- if $pedagogy -}}
+            <li><a {{ partial "AnchorAttribute" (i18n "programs.pedagogy") }}>{{ i18n "programs.pedagogy" }}</a></li>
+          {{- end -}}
+          {{- if $evaluation -}}
+            <li><a {{ partial "AnchorAttribute" (i18n "programs.evaluation") }}>{{ i18n "programs.evaluation" }}</a></li>
+          {{- end -}}
+          {{- if $teachers -}}
+            <li><a {{ partial "AnchorAttribute" (i18n "programs.teachers") }}>{{ i18n "programs.teachers" }}</a></li>
+          {{- end -}}
+        </ol>
+      </li>
+    {{ end -}}
     <li>
       <a {{ partial "AnchorAttribute" ( i18n "programs.toc.results" ) }} >{{ i18n "programs.toc.results" }}</a>
       {{- if or $opportunities $results }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La partie "Admission" ne s'affichait que si le contenu était rempli. Dans cette PR, on affiche la section "Admission" même si seul le lien d'inscription est rempli.

On en profite pour affiner les conditions d'affichage de la TOC.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

