### PR TITLE
Ajout d'un paramètre dans la config yaml, pour enlever du head la balise meta no-referrer

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -38,6 +38,7 @@ params:
   seo:
     title:
       separator: "|"
+    head_no_referrer: true # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referer
 
   # DESIGN SYSTEM
   logo:

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -72,8 +72,10 @@
   <meta name="{{ .name }}" content="{{ .content }}">
 {{ end }}
 
-{{/*
-Limiter le tracking par le CDN
-https://framagit.org/chatons/CHATONS/-/issues/200#note_1987024
-*/}}
-<meta name="referrer" content="no-referrer">
+{{ if site.Params.seo.head_no_referrer }}
+    {{/*
+    Limiter le tracking par le CDN
+    https://framagit.org/chatons/CHATONS/-/issues/200#note_1987024
+    */}}
+    <meta name="referrer" content="no-referrer">
+{{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description
CF issue, ce nouveau paramètre permettrait de ne pas rendre la balise `<meta name="referrer" content="no-referrer">`, si besoin sur un projet.


## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
https://github.com/osunyorg/theme/issues/1304


