### PR TITLE
Sidebar des offres d'emploi : ajout d'options pour masquer des éléments

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -254,6 +254,10 @@ params:
         dates: true
         with_more: true
       truncate_description: 200 # Set to 0 to disable truncate
+    single:
+      options:
+        authors: true
+        reading_time: true
   journals:
     index:
       layout: list

--- a/layouts/partials/jobs/single/job-infos.html
+++ b/layouts/partials/jobs/single/job-infos.html
@@ -29,9 +29,13 @@
     {{ end }}
   {{ end }}
 
-  {{ partial "authors/partials/authors.html" . }}
+  {{ if site.Params.jobs.single.options.authors }}
+    {{ partial "authors/partials/authors.html" . }}
+  {{ end }}
 
-  {{ partial "commons/reading-time.html" . }}
+  {{ if site.Params.jobs.single.options.reading_time }}
+    {{ partial "commons/reading-time.html" . }}
+  {{ end }}
 
   {{ if site.Params.jobs.share_links.enabled | default site.Params.share_links.enabled }}
     {{ partial "commons/share/list-item.html" . }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajout de deux options, sur le modèle de post, pour gérer l'affichage des infos dont on peut se dispenser : 
- les auteurs et autrices
- le temps de lecture

C'est une demande de la GL, ça me semble plutôt compréhensible de vouloir masquer le temps de lecture (j'en ai profité pour gérer les auteurs et autrices)

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)


## URL de test sur example.osuny.org

`/fr/offres-d-emploi/2025/offre-demploi-test-1/`

## URL de test du site GL

`/rejoindre-l-equipe/offres-d-emploi/2025/responsable-accueil-billetterie/`

## Screenshots
<img width="610" height="297" alt="Capture d’écran 2026-01-14 à 16 44 04" src="https://github.com/user-attachments/assets/68da71a3-3c93-44da-be1b-70a1d22893f8" /><img width="603" height="248" alt="Capture d’écran 2026-01-14 à 16 43 55" src="https://github.com/user-attachments/assets/2dc47b7d-7df2-4ac8-aaa6-fa1a3d20514f" />