### PR TITLE
Bloc liens : ajustement du style et ajout d'un traitement des images selon le layout

### DIFF
--- a/assets/sass/_theme/blocks/links.sass
+++ b/assets/sass/_theme/blocks/links.sass
@@ -22,6 +22,12 @@
             &--icon
                 img
                     max-width: $block-links-icon-max-width
+
+    &:where(:not(.block-links--cards))
+        .link-content
+            a
+                @include h3
+
     &--grid
         ul
             @include grid(1, false, $spacing-4)
@@ -30,9 +36,6 @@
             flex-direction: column
             gap: $spacing-2
             .link-content
-                a
-                    @include h3
-                    @include set-inner-icon(links-line)
                 p
                     margin-top: space()
             .media
@@ -46,10 +49,7 @@
             padding-bottom: $spacing-2
             + li
                 border-top: 1px solid var(--color-border)
-            a
-                @include h3
-                &[target="_blank"]
-                    @include set-inner-icon(links-line, $pseudo-element: after, $target: "span[itemprop='name']")
+            
             @include media-breakpoint-down(md)
                 flex-direction: column
                 gap: $spacing-2

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -559,9 +559,22 @@ params:
         tablet:   100
         desktop:  150
       links:
-        mobile:   350
-        tablet:   400
-        desktop:  600
+        icons: 
+          mobile:   40
+          tablet:   40
+          desktop:  40
+        cards:
+          mobile:   350
+          tablet:   400
+          desktop:  600
+        grid:
+          mobile:   360
+          tablet:   555
+          desktop:  575
+        list:
+          mobile:   245
+          tablet:   245
+          desktop:  245
       testimonials:
         mobile:   80
         tablet:   160

--- a/layouts/partials/blocks/templates/links.html
+++ b/layouts/partials/blocks/templates/links.html
@@ -3,6 +3,7 @@
 
 {{- with .block.data -}}
   {{ $options := .options }}
+  {{ $layout := .layout }}
   <div class="{{ $block_class }}">
     <div class="container">
       <div class="block-content">
@@ -26,11 +27,16 @@
                 {{ end }}
               </div>
               {{- if .image -}}
+                {{- $sizes := (index site.Params.image_sizes.blocks.links $layout) -}}
+                {{ if $options.icons }}
+                  {{ $sizes = site.Params.image_sizes.blocks.links.icons }}
+                {{ end }}
+                
                 <div class="media {{- if $options.icons }} media--icon {{- end }}">
                   {{- partial "commons/image.html" (dict
                     "image" .image
                     "alt" .alt
-                    "sizes" site.Params.image_sizes.blocks.links
+                    "sizes" $sizes
                   ) -}}
                 </div>
               {{- end -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

- Correction de l'icône des liens externe en layout grille : elle s'appliquait à tous les liens
- Pour GL : besoin d'avoir une taille d'image importante pour le format grille (cela va dans le sens de l'ajout récente des différents layouts).

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-techniques/liens/`