### PR TITLE
Ajout des sous-titres aux pages (single)

### DIFF
--- a/layouts/partials/pages/single/hero.html
+++ b/layouts/partials/pages/single/hero.html
@@ -1,5 +1,9 @@
 {{- $title := or .Params.header_text .Title -}}
 
+{{ with .Params.subtitle }}
+  {{- $title = printf "%s <span>%s</span>" $title . -}}
+{{ end }}
+
 {{- partial "header/hero.html" (dict
   "title" $title
   "image" .Params.image


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La PR [admin#3562](https://github.com/osunyorg/admin/pull/3562/) ajoute les sous-titres aux pages.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1314/fr/blocks/quest-ce-quun-bloc/`

## URL de test du site (optionnel)

`http://localhost:1313/fr/programmation/cycle-thematique-festina-lente-hate-toi-lentement/`

## Screenshots

<img width="1466" height="800" alt="Capture d’écran 2026-01-29 à 12 27 25" src="https://github.com/user-attachments/assets/72539ad6-c4dc-46fc-8cd3-02dcda175b3c" />
<img width="1469" height="799" alt="image" src="https://github.com/user-attachments/assets/807197f2-709d-4ba9-894f-d77cc52a89d5" /><img width="389" height="680" alt="Capture d’écran 2026-01-29 à 12 27 36" src="https://github.com/user-attachments/assets/ef15aeaa-26e0-46b4-8255-fd9aef0c6006" />
<img width="389" height="683" alt="Capture d’écran 2026-01-29 à 12 34 11" src="https://github.com/user-attachments/assets/a7dbd63d-0487-4575-bf62-b68fff0c1f36" />