### PR TITLE
Ordonner les événements par heure de début dans l'agenda

### DIFF
--- a/layouts/partials/events/partials/agenda.html
+++ b/layouts/partials/events/partials/agenda.html
@@ -11,7 +11,7 @@
         <h2 class="events-date-title" id="{{ anchorize .Key }}"><span>{{ .Key | strings.FirstUpper | safeHTML }}</span></h2>
       {{ end }}
       <ol class="events-scheduled">
-        {{ range .Pages }}
+        {{ range .Pages.ByParam "current_time_slot.start.datetime" }}
           {{ if .Params.children_for_the_day }}
             {{ $event_attributes := printf "%s %s" "ok" "itemprop='superEvent'" }}
           {{ end}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajouter un tri sur le current_timeslot start datetime pour ordonner par heure les événements d'un même jour.

⚠️ Cela est un patch temporaire, le mieux étant de corriger la donnée `date` dans le static en lui ajoutant l'heure de début du timeslot.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

https://github.com/osunyorg/theme/issues/1318
