### PR TITLE
Bloc vidéo : correction de l'erreur 153 sur safari

### DIFF
--- a/assets/js/theme/blocks/videos.js
+++ b/assets/js/theme/blocks/videos.js
@@ -13,6 +13,7 @@ window.osuny.VideoPlayer = function (element) {
     this.button = this.cover.querySelector('button');
     this.iframe = this.element.querySelector('.video-container iframe');
     this.src = this.iframe.getAttribute('data-unloaded-src');
+    this.iframe.removeAttribute('data-unloaded-src');
 
     this.button.addEventListener('click', this.play.bind(this));
 };
@@ -20,6 +21,7 @@ window.osuny.VideoPlayer = function (element) {
 window.osuny.VideoPlayer.prototype.play = function () {
     this.cover.style.display = 'none';
     this.iframe.src = this.src;
+    this.iframe.parentNode.append(this.iframe);
 };
 
 window.osuny.VideoPlayer.prototype.cloneIframe = function () {


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Pour corriger l'erreur 153 Youtube sur le bloc vidéo sur Safari, on recharge l'iframe dans la page.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


