### PR TITLE
Sitemap : ajustement du style des icônes

### DIFF
--- a/assets/sass/_theme/blocks/sitemap.sass
+++ b/assets/sass/_theme/blocks/sitemap.sass
@@ -11,7 +11,6 @@
         li
             position: relative
             ul
-                margin-left: $spacing-3
                 li
                     a
                         @include icon(corner-down-right-line)


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On enlève le soulignement inélégant des icônes dans le plan du site.

## URL de test sur example.osuny.org

`http://localhost:1313/fr/plan-du-site/`

## URL de test du site (optionnel)

`http://localhost:1314/plan-du-site/`

## Screenshots
<img width="599" height="346" alt="Capture d’écran 2026-02-02 à 16 34 48" src="https://github.com/user-attachments/assets/51a89483-cee8-4853-9d56-cea21bb73d85" />
<img width="778" height="374" alt="Capture d’écran 2026-02-02 à 16 36 25" src="https://github.com/user-attachments/assets/958f0ce4-85a5-47a6-803b-5c424f6d39d6" />


