### PR TITLE
Retirer le tri par la clé `current_time_slot`

### DIFF
--- a/layouts/partials/events/partials/agenda.html
+++ b/layouts/partials/events/partials/agenda.html
@@ -11,7 +11,7 @@
         <h2 class="events-date-title" id="{{ anchorize .Key }}"><span>{{ .Key | strings.FirstUpper | safeHTML }}</span></h2>
       {{ end }}
       <ol class="events-scheduled">
-        {{ range .Pages.ByParam "current_time_slot.start.datetime" }}
+        {{ range .Pages }}
           {{ if .Params.children_for_the_day }}
             {{ $event_attributes := printf "%s %s" "ok" "itemprop='superEvent'" }}
           {{ end}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Suite de https://github.com/osunyorg/theme/pull/1319

À passer une fois que les statics seront à jour : https://github.com/osunyorg/admin/pull/3759


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

