### PR TITLE
Bloc témoignage : tester la présence du texte

### DIFF
--- a/layouts/partials/blocks/templates/testimonials/carousel.html
+++ b/layouts/partials/blocks/templates/testimonials/carousel.html
@@ -10,10 +10,12 @@
     {{ end }}
 
     <figure class="testimonial {{ if.photo }}with-picture{{ end }}" 
-            {{ with $aria_label -}} role="figure" aria-label="{{ . }}" {{- end }}>
-      {{ $is_long := gt (len .text) 150 }}
+      {{ with $aria_label -}} role="figure" aria-label="{{ . }}" {{- end }}>
+      {{ $text := .text | default "" }}
+
+      {{ $is_long := gt (len $text) 150 }}
       <blockquote {{- if $is_long }} class="is-long" {{- end }}>
-        {{- partial "PrepareHTML" .text -}}
+        {{- partial "PrepareHTML" $text -}}
       </blockquote>
       {{ if or .photo .author .job -}}
         <figcaption>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Il faut tester la présence du texte dans un témoignage pour ne pas générer d'erreur dûe à l'absence de clé.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


