### PR TITLE
Interlignage du style de texte `meta` 

### DIFF
--- a/assets/sass/_theme/configuration/typography.sass
+++ b/assets/sass/_theme/configuration/typography.sass
@@ -127,7 +127,7 @@ $signature-letter-spacing: normal !default
 $meta-font-family: $heading-font-family !default
 $meta-size-desktop: pxToRem(16) !default
 $meta-size: pxToRem(14) !default
-$meta-line-height: 150% !default
+$meta-line-height: 100% !default
 $meta-line-height-desktop: $meta-line-height !default
 $meta-weight: $heading-font-weight !default
 $meta-text-transform: none !default


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Mettre line-height à ~~100%~~ 130% desktop et 150% mobile par défaut pour les textes `meta`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


