### PR TITLE
Afficher un message lorsqu'il n'y a pas d'expositions en cours

### DIFF
--- a/layouts/partials/exhibitions/partials/exhibitions.html
+++ b/layouts/partials/exhibitions/partials/exhibitions.html
@@ -4,16 +4,20 @@
 {{ $heading_level := .heading_level | default 2 }}
 {{ $with_more := or (eq $layout "agenda") site.Params.exhibitions.list.with_more }}
 
-<ol class="exhibitions exhibitions--{{- $layout }}">
-  {{ range $exhibitions }}
-    <li>
-      {{ partial "exhibitions/partials/exhibition.html" (dict
-        "exhibition" .
-        "heading_level" $heading_level
-        "layout" $layout
-        "options" $options
-        "with_more" $with_more
-      ) }}
-    </li>
-  {{ end }}
-</ol>
+{{ if not $exhibitions }}
+  <p class="none">{{ i18n "exhibitions.none" }}</p>
+{{ else }}
+  <ol class="exhibitions exhibitions--{{- $layout }}">
+    {{ range $exhibitions }}
+      <li>
+        {{ partial "exhibitions/partials/exhibition.html" (dict
+          "exhibition" .
+          "heading_level" $heading_level
+          "layout" $layout
+          "options" $options
+          "with_more" $with_more
+        ) }}
+      </li>
+    {{ end }}
+  </ol>
+{{ end }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Afficher un message dans l'index des expositions lorsqu'il n'y a pas de message.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


