### PR TITLE
Papiers des personnes : li tag en trop

### DIFF
--- a/layouts/_partials/persons/single/papers.html
+++ b/layouts/_partials/persons/single/papers.html
@@ -5,9 +5,7 @@
   </div>
   <ul class="papers">
     {{ range first 3 .papers }}
-    <li>
       {{ partial "papers/partials/paper.html" (dict "paper" .) }}
-    </li>
     {{ end }}
   </ul>
   <a href="{{ $researcher.Permalink }}" class="more">{{ i18n "persons.papers.all" (dict "author" $researcher.Params.person) }}</a>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Dans les papiers des personnes, il y a un <li> tag en trop.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


