### PR TITLE
Windows : correction de l'unité `vw` 

### DIFF
--- a/assets/js/theme/index.js
+++ b/assets/js/theme/index.js
@@ -1,6 +1,6 @@
 import './polyfills';
 import './utils/utils';
-import './utils/realViewportHeight';
+import './utils/realViewportDimensions';
 
 import './page';
 import './design-system/events';

--- a/assets/js/theme/utils/realViewportDimensions.js
+++ b/assets/js/theme/utils/realViewportDimensions.js
@@ -1,0 +1,20 @@
+function setRealViewportHeight () {
+    var rvh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--rvh', rvh + 'px');
+};
+
+function setRealViewportWidth () {
+    // https://destroytoday.com/blog/100vw-and-the-horizontal-overflow-you-probably-didnt-know-about
+    // The window.innerWidth does not return the real viewport width, it's include scrollbar (that is ignored by css's unit `vw`)
+    var rvw = document.body.clientWidth * 0.01;
+    document.documentElement.style.setProperty('--rvw', rvw + 'px');
+};
+
+function setRealViewportSize () {
+    setRealViewportHeight();
+    setRealViewportWidth();
+};
+
+window.addEventListener('load', setRealViewportSize);
+window.addEventListener('resize', setRealViewportSize);
+

--- a/assets/js/theme/utils/realViewportHeight.js
+++ b/assets/js/theme/utils/realViewportHeight.js
@@ -1,8 +1,0 @@
-var setRealViewportHeight = function () {
-    var rvh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty('--rvh', rvh + 'px');
-};
-
-window.addEventListener('load', setRealViewportHeight);
-window.addEventListener('resize', setRealViewportHeight);
-

--- a/assets/sass/_theme/_variables.sass
+++ b/assets/sass/_theme/_variables.sass
@@ -160,7 +160,7 @@
   // Elle inclut les gouttières extérieures
   // Si la largeur de l'écran est inférieure à 1980px, on prend la largeur totale.
   // La grille n'est jamais plus grande que 1980px
-  --grid-width: Min(var(--grid-max-width), 100vw)
+  --grid-width: Min(var(--grid-max-width), #{rvw(100)})
 
   // Largeur d'une colonne
   // On soustrait à la largeur de la grille les 13 gouttières (les 2 extérieures et les 11 intérieures), puis on divise par 12

--- a/assets/sass/_theme/design-system/layout.sass
+++ b/assets/sass/_theme/design-system/layout.sass
@@ -5,6 +5,7 @@
 
 \:root
     --rvh: 1vh
+    --rvw: 1vw
     --spacing-1: #{$spacing-1}
     --spacing-2: #{$spacing-2}
     --spacing-3: #{$spacing-3}

--- a/assets/sass/_theme/utils/sizes.sass
+++ b/assets/sass/_theme/utils/sizes.sass
@@ -8,3 +8,6 @@ $space-unit: 4 !default
 
 @function rvh($percent)
     @return calc(#{$percent} * var(--rvh))
+
+@function rvw($percent)
+    @return calc(#{$percent} * var(--rvw))


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Sur Windows, l'unité CSS `vw` inclue la largeur de la barre de scroll horizontale. Cela créé un écart de dimension entre l'espace réelle disponible de la page et la valeur relative calculée par `vw`.

Par exemple, sur un écran de 1920px de large : 100vw est égale à 1920px. Mais la place réelle disponible dans la page est 1905px. Cette valeur ne peut pas être récupérer directement via CSS. On ajoute donc le calcul en javascript de la place réelle disponible et on ajoute une fonction sass pour la récupérer : 

```
@function rvw($percent)
    @return calc(#{$percent} * var(--rvw))
```

```
--grid-width: Min(var(--grid-max-width), #{rvw(100)})
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱


## Screenshots

Avant : 

<img width="1625" height="610" alt="image" src="https://github.com/user-attachments/assets/1cdb3e16-7d2c-4ca5-af8a-1a0e8a43a780" />

Après :

<img width="1675" height="706" alt="image" src="https://github.com/user-attachments/assets/f858b805-76f9-4bab-9214-cd2b1158d2da" />