### PR TITLE
Meilleur débug pour les écrans sombres

### DIFF
--- a/layouts/_partials/debug/debug.html
+++ b/layouts/_partials/debug/debug.html
@@ -1,9 +1,11 @@
-{{ partial "debug/tools/blocks" }}
-{{ partial "debug/tools/cross" }}
-{{ partial "debug/tools/grid" }}
-{{ partial "debug/tools/help" }}
-{{ partial "debug/tools/images" }}
-{{ partial "debug/tools/non-regression" . }}
-{{ partial "debug/tools/open-in-production" }}
-{{ partial "debug/tools/spacing" }}
-{{ partial "debug/tools/full-width" }}
+<div class="osuny-debug">
+  {{ partial "debug/tools/blocks" }}
+  {{ partial "debug/tools/cross" }}
+  {{ partial "debug/tools/grid" }}
+  {{ partial "debug/tools/help" }}
+  {{ partial "debug/tools/images" }}
+  {{ partial "debug/tools/non-regression" . }}
+  {{ partial "debug/tools/open-in-production" }}
+  {{ partial "debug/tools/spacing" }}
+  {{ partial "debug/tools/full-width" }}
+</div>

--- a/layouts/_partials/debug/tools/grid.html
+++ b/layouts/_partials/debug/tools/grid.html
@@ -19,8 +19,6 @@
     display: none;
     grid-gap: var(--grid-gutter);
     grid-template-columns: repeat(12, 1fr);
-    opacity: 0.2;
-    mix-blend-mode: multiply;
     padding: 0 var(--grid-gutter);
     pointer-events: none;
     position: fixed;
@@ -38,7 +36,9 @@
     display: grid;
   }
   .d-grid > div {
-    background: fuchsia;
+    background: rgba(255,0,255,0.2);
+    border-left: 1px solid fuchsia;
+    border-right: 1px solid fuchsia;
     text-align: center;
   }
   @media (max-width: 768px) {


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

La grille a maintenant des bords sans transparence, pour voir ce que l'on fait sur un fond sombre. Il n'y a plus de blend mode. Tout le debugger est regroupé dans un div `osuny-debug`.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


