### PR TITLE
Correction du niveau de titre des expositions liées au formation

### DIFF
--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -5,7 +5,6 @@
                 border-bottom: var(--border-width) solid var(--color-border)
                 margin-bottom: $spacing-3
                 padding-bottom: $spacing-3
-        
         .event
             display: flex
             flex-direction: column
@@ -62,8 +61,8 @@
                     width: columns(10)
                     > .event-title, 
                     > hgroup, 
-                    .event-categories, 
-                    .event-description, 
+                    .event-categories,
+                    .event-description,
                     .event-parent,
                     .event-status
                         grid-column: 5 / 11
@@ -97,6 +96,9 @@
                 margin-top: $spacing-2
             &-description
                 margin-top: $spacing-2
+            &-content
+                .event-title, hgroup
+                    @include h3
             .media
                 margin-bottom: $spacing-2
                 order: -1

--- a/assets/sass/_theme/sections/exhibitions/layouts.sass
+++ b/assets/sass/_theme/sections/exhibitions/layouts.sass
@@ -2,6 +2,10 @@
     @include list-reset
     &--list
         @include layout-list
+        .exhibition
+            &-title,
+            &-subtitle
+                @include h3
     &--grid
         @include layout-grid(2)
         .exhibition

--- a/assets/sass/_theme/sections/programs.sass
+++ b/assets/sass/_theme/sections/programs.sass
@@ -309,7 +309,7 @@ ol.programs--light
                 border-top: var(--border-width) solid var(--color-border)
     .program-related
         .content
-            h2
+            > h2
                 margin-bottom: $spacing-2
             .category-link
                 display: block
@@ -320,6 +320,11 @@ ol.programs--light
             .blocks
                 --block-space-y: 0
                 padding-top: 0
+                .block[class$="--list"]
+                    hgroup,
+                    [class$="-title"],
+                    [class$="-subtitle"]
+                        @include h3
             .projects--list > li:first-child
                 padding-top: 0
     .program-updated

--- a/layouts/_partials/programs/single/core/related/events.html
+++ b/layouts/_partials/programs/single/core/related/events.html
@@ -17,9 +17,9 @@
           {{ partial "blocks/templates/agenda.html" (dict
             "block" (dict 
               "template" "agenda"
-              "ranks" (dict 
+              "ranks" (dict
                 "base" 2
-                "self" 2
+                "children" 3
               )
               "data" (dict
                 "events" $events

--- a/layouts/_partials/programs/single/core/related/exhibitions.html
+++ b/layouts/_partials/programs/single/core/related/exhibitions.html
@@ -17,9 +17,9 @@
           {{ partial "blocks/templates/exhibitions.html" (dict
             "block" (dict 
               "template" "exhibitions"
-              "ranks" (dict 
+              "ranks" (dict
                 "base" 2
-                "self" 2
+                "children" 3
               )
               "data" (dict
                 "exhibitions" $exhibitions

--- a/layouts/_partials/programs/single/core/related/posts.html
+++ b/layouts/_partials/programs/single/core/related/posts.html
@@ -19,7 +19,7 @@
               "template" "posts"
               "ranks" (dict
                 "base" 2
-                "self" 2
+                "children" 3
               )
               "data" (dict
                 "posts" $posts

--- a/layouts/_partials/programs/single/core/related/projects.html
+++ b/layouts/_partials/programs/single/core/related/projects.html
@@ -19,7 +19,7 @@
               "template" "projects"
               "ranks" (dict
                 "base" 2
-                "self" 2
+                "children" 3
               )
               "data" (dict
                 "projects" $projects


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les titres des expositions liées doivent être des h3 et non des h2.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
