### PR TITLE
Style mobile de la TOC

### DIFF
--- a/assets/sass/_theme/configuration/zindex.sass
+++ b/assets/sass/_theme/configuration/zindex.sass
@@ -10,7 +10,8 @@ $zindex-modal: 72 !default
 $zindex-nav-accessibility: 1010 !default
 $zindex-offcanvas: 60 !default
 $zindex-toc: 50 !default
-$zindex-toc-cta: 49 !default
+$zindex-toc-cta: 56 !default
+$zindex-toc-cta-when-menu-opened: 49 !default
 $zindex-search-button-fixed: 51 !default
 $zindex-stretched-link: 2 !default
 $zindex-up-leaflet-map: 500 !default

--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -74,12 +74,15 @@
     @include media-breakpoint-down(desktop)
         border-top: $toc-border-width solid var(--color-border)
         position: fixed
-        bottom: 0
+        bottom: -200px
         background: $toc-background-color
         left: 0
         width: 100%
         padding: 0 var(--grid-gutter)
+        padding-bottom: 200px
         z-index: $zindex-toc-cta
+        html.has-menu-opened &
+            z-index: $zindex-toc-cta-when-menu-opened
     button
         @include link-icon(menu-3-line)
         border: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Pour éviter l'étrange superposition liée au bouton flottant de certain navigateur / OS, on prolonge le bouton de la TOC plus bas.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

### Le problème 


<img width="563" height="1218" alt="IMG_1845" src="https://github.com/user-attachments/assets/7d06fb9f-38dc-4a83-a7e5-a56077f8211b" />


### Résolution ?

#### iOS iPhone 13 min

##### Safari

<img width="563" height="1218" alt="IMG_1846" src="https://github.com/user-attachments/assets/347761b5-9ce0-4474-b618-1278d0458f08" />


##### Firefox



