### PR TITLE
Réparation de Leaflet (referrer-policy)

### DIFF
--- a/assets/js/theme/design-system/components/Maps.js
+++ b/assets/js/theme/design-system/components/Maps.js
@@ -42,8 +42,9 @@ window.osuny.Map.prototype.setMap = function () {
     });
 
     this.layers = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         maxZoom: 19,
-        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        referrerPolicy: "origin"
     });
 
     this.layers.addTo(this.map);


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les tiles leaflet nécessite désormais un referrer policy. On ajoute le paramètre à la génération de la carte en js.

Nous suivons [cette PR](https://github.com/Leaflet/Leaflet/pull/9883), après la mise à jour de leaflet, il n'y aura plus besoin de préciser la referrer policy.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
