### PR TITLE
Correction temporaire de `page.children`

### DIFF
--- a/layouts/_partials/pages/partials/children.html
+++ b/layouts/_partials/pages/partials/children.html
@@ -14,7 +14,7 @@
         {{ $pages = $pages | append $page }}
       {{ end }}
       {{ partial (printf "pages/partials/layouts/%s/%s.html" site.Params.pages.index.layout site.Params.pages.index.layout) (dict 
-        "pages" .Pages
+        "pages" $pages
         "heading_level" 2
         "options" $options
       ) }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

En attendant une donnée homogène, on patch la récupération des enfants des pages.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
