### PR TITLE
Grille de page : ajustement du sélecteur de la description

### DIFF
--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -28,5 +28,5 @@
                 a
                     @include icon(arrow-right-line, after, true)
                     @include hover-translate-icon(after)
-                + p
+                + .page-description
                     margin-top: $spacing-1


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

On continuait à cibler le sélecter `p` après le titre d'une page, ce qui, avec l'ajout de `div.page-description` ne fonctionnait plus : 

**En ligne :** 
<img width="1340" height="927" alt="Capture d’écran 2026-04-01 à 17 02 15" src="https://github.com/user-attachments/assets/6ca453d6-a9e7-4293-b4f3-1cf9a70d29a7" />
.
.
.
**En local sur la v9.2.0 :** 
<img width="1335" height="785" alt="Capture d’écran 2026-04-01 à 17 01 57" src="https://github.com/user-attachments/assets/0cb14a95-43af-4e22-af36-912a1bbba6f5" />

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)



## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


