### PR TITLE
Style des sous-titres dans le bloc de pages

### DIFF
--- a/assets/sass/_theme/blocks/pages.sass
+++ b/assets/sass/_theme/blocks/pages.sass
@@ -56,6 +56,7 @@
             > li
                 border-bottom: none
                 padding: 0
+                hgroup,
                 .page-title
                     @include h3
                 + li
@@ -153,6 +154,7 @@
                 margin-top: $spacing-1
             .more
                 margin-top: $spacing-2
+    
     &--large
         .pages
             @include layout-large

--- a/assets/sass/_theme/design-system/layouts/cards.sass
+++ b/assets/sass/_theme/design-system/layouts/cards.sass
@@ -9,6 +9,7 @@
         padding: $spacing-3
         position: relative
         transition: background $background-duration, color $background-duration
+        hgroup,
         [class$="-title"]
             @include h3
             a

--- a/assets/sass/_theme/design-system/layouts/large.sass
+++ b/assets/sass/_theme/design-system/layouts/large.sass
@@ -6,6 +6,7 @@
         @include article
         @include layout-item
         @include small-arrow-right-hover('.more')
+        hgroup,
         [class$="-title"]
             @include h2
         @include media-breakpoint-down(desktop)

--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -126,6 +126,9 @@
     &--large
         @include layout-large
         .event
+            &-subtitle,
+            hgroup
+                @include h2
             &-dates
                 @include h4
                 margin-top: $spacing-2

--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -126,7 +126,7 @@
     &--large
         @include layout-large
         .event
-            &-subtitle,
+            &-title,
             hgroup
                 @include h2
             &-dates

--- a/assets/sass/_theme/sections/pages.sass
+++ b/assets/sass/_theme/sections/pages.sass
@@ -1,7 +1,10 @@
 .page
     @include article($aspect-ratio: $page-media-aspect-ratio)
+    hgroup,
     .page-title
         @include h4
+    .page-subtitle
+        color: var(--color-text-alt)
     .more
         @include icon(arrow-right-line, after, true)
         @include hover-translate-icon(after)
@@ -23,6 +26,7 @@
     &--grid
         @include layout-grid
         .page
+            hgroup,
             .page-title
                 @include h3
                 a

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -281,6 +281,7 @@ params:
         categories: false
         image: true
         main_summary: false
+        subtitle: false
         summary: true
       truncate_description: 200 # Set to 0 to disable truncate
     single:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -281,7 +281,7 @@ params:
         categories: false
         image: true
         main_summary: false
-        subtitle: false
+        subtitle: true
         summary: true
       truncate_description: 200 # Set to 0 to disable truncate
     single:


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

- Ajout de la gestion de l'option `subtitle` dans le bloc de pages -> usage du hgroup
- Ajustement du sous-titre d'un événement en large (actuellement h4, normalement h2/lead comme le titre)

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)
- [PR admin](https://github.com/osunyorg/admin/pull/3746)
- [figma](https://www.figma.com/design/tQh3oLfNwSt8aoVDuUjQt0/Th%C3%A8me-Osuny?node-id=11179-9631&t=I7QZacotWUssKsHL-1)

## URL de test sur example.osuny.org

http://localhost:1313/fr/blocks/blocs-de-liste/pages/
http://localhost:1313/fr/blocks/blocs-de-liste/agenda-1/#layout-grand

## Screenshots

<img width="1918" height="957" alt="Capture d’écran 2026-04-07 à 10 02 02" src="https://github.com/user-attachments/assets/9227fb03-d24b-493c-8dfe-5af825aa7496" />
<img width="1916" height="860" alt="Capture d’écran 2026-04-07 à 10 12 20" src="https://github.com/user-attachments/assets/4109718e-93d4-4f99-87d1-1b592b69e5af" />
<img width="1918" height="905" alt="Capture d’écran 2026-04-07 à 10 23 36" src="https://github.com/user-attachments/assets/13164c56-b506-4c08-8e25-02c4efdde175" />
<img width="1917" height="956" alt="Capture d’écran 2026-04-07 à 10 01 47" src="https://github.com/user-attachments/assets/a292d63a-fc0e-48b3-87a2-27dd17c2728f" />

----

Événements :

<img width="1430" height="957" alt="Capture d’écran 2026-04-07 à 10 19 05" src="https://github.com/user-attachments/assets/257c56cc-efa0-4e8d-b73e-c41a7ff617a7" />
<img width="1425" height="956" alt="image" src="https://github.com/user-attachments/assets/ce9c1ce4-1f28-4c62-a83f-e5a8425f3bc0" />
