### PR TITLE
Éviter les duplications d'événements dans la single d'une catégorie

### DIFF
--- a/layouts/_partials/events_categories/helpers/GetChildrenFromSharedParentCategory.html
+++ b/layouts/_partials/events_categories/helpers/GetChildrenFromSharedParentCategory.html
@@ -1,0 +1,14 @@
+{{/*  This avoid events children duplication in term single. This happen when a child event share the same category as its parent  */}}
+{{ $term := .term }}
+{{ $child_events := where .events "Params.dates.event.is_child" true }}
+{{ $children_with_same_category := slice }}
+
+{{ range $index, $child := $child_events }}
+  {{ with site.GetPage .Params.parent.path }}
+    {{ if in .Params.events_categories $term.Slug }}
+      {{ $children_with_same_category = $children_with_same_category | append $child }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $children_with_same_category  }}

--- a/layouts/_partials/events_categories/helpers/GetChildrenFromSharedParentCategory.html
+++ b/layouts/_partials/events_categories/helpers/GetChildrenFromSharedParentCategory.html
@@ -11,4 +11,4 @@
   {{ end }}
 {{ end }}
 
-{{ return $children_with_same_category  }}
+{{ return $children_with_same_category }}

--- a/layouts/_partials/events_categories/helpers/GetPaginator.html
+++ b/layouts/_partials/events_categories/helpers/GetPaginator.html
@@ -1,5 +1,11 @@
 {{ $events := where .Pages "Section" "events" }}
 
+{{ $children_with_same_category := partial "events_categories/helpers/GetChildrenFromSharedParentCategory" (dict
+  "term" .
+  "events" $events
+) }}
+{{ $events = $events | complement $children_with_same_category }}
+
 {{ $futur_and_current := where $events "Params.dates.archive" false }}
 {{ $futur_and_current_group := $futur_and_current.GroupByDate site.Params.events.index.group_by_date "asc" }}
 


### PR DESCRIPTION

## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Dans les catégories d'événements, si un événement enfant possède la même catégorie que son parent, il est dupliqué : en tant qu'enfant et en tant qu'événement seul.

Pour éviter cette duplication, on va chercher dans les événement enfants leur parent, puis vérifier si la catégorie (term) correspond à la catégorie du parent. Si c'est le cas, on observe la catégorie de l'enfant et si c'est la même que celle du parent, on stock l'enfant dans la liste des événements à révoquer de la pagination des événement.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/gaitelyrique-www/issues/142#issuecomment-4212720330

## URL de test sur example.osuny.org

[branch]--example.osuny.netlify.app

## URL de test du site (optionnel)



## Screenshots


