### PR TITLE
Rétro-compatibilité des icônes des blocs fonctionnalités

### DIFF
--- a/assets/sass/_theme/blocks/features.sass
+++ b/assets/sass/_theme/blocks/features.sass
@@ -32,7 +32,23 @@
                 
                 @include media-breakpoint-down(desktop)
                     margin-bottom: $spacing-2
-    
+            // Legacy
+            &:not(.media--icon, .media--image)
+                picture
+                    img
+                        margin: auto
+                picture:not(.is-png, .is-svg)
+                    img
+                        object-fit: cover
+                        width: 100%
+                        aspect-ratio: 16/9
+                picture.is-png
+                    padding-top: $spacing-3
+                    img
+                        margin: initial
+                        max-width: $block-features-icon-max-width
+                    @include media-breakpoint-down(desktop)
+                        margin-bottom: $spacing-2
     @include in-page-with-sidebar
         .feature
             flex-direction: row
@@ -43,6 +59,11 @@
                 &.media--icon
                     img
                         margin: auto
+                // Legacy
+                &:not(.media--icon, .media--image)
+                    picture.is-png
+                        img
+                            margin: auto
 
     @include in-page-without-sidebar
         .top

--- a/layouts/_partials/blocks/templates/features/feature/media.html
+++ b/layouts/_partials/blocks/templates/features/feature/media.html
@@ -1,4 +1,8 @@
-{{ $media_type := cond .options.icons "icon" "image" }}
+{{ $options := .options }}
+{{ $media_type := "" }}
+{{ with $options }}
+  {{ $media_type = cond .icons "icon" "image" }}
+{{ end }}
 
 <figure class="media media--{{ $media_type }}" {{ with or .feature.alt .feature.credit }} role="figure" aria-label="{{ . | plainify }}" {{ end }}>
   {{ partial "commons/image.html" (dict


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Support de la rétro-compatibilité des blocs fonctionnalités avec ou sans icônes.

Cet ajout est à retirer une fois tous les sites migrés et la release 9.2.0 déployée.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
