### PR TITLE
Icônes : pouvoir overrider partiellement les icônes osuny

### DIFF
--- a/assets/sass/_theme/configuration/icons.sass
+++ b/assets/sass/_theme/configuration/icons.sass
@@ -62,3 +62,4 @@ $icon-social-margin-right: -14px
 
 $icons-custom: false !default
 $icons-custom-font-family: false !default
+$icons-custom-size-ratio: false !default

--- a/assets/sass/_theme/configuration/icons.sass
+++ b/assets/sass/_theme/configuration/icons.sass
@@ -59,3 +59,6 @@ $icon-close-margin-right: -12px
 $icon-toc-margin-right: -14px
 $icon-arrow-previous-margin-left: -18px // cf. testimonial
 $icon-social-margin-right: -14px
+
+$icons-custom: false !default
+$icons-custom-font-family: false !default

--- a/assets/sass/_theme/configuration/icons.sass
+++ b/assets/sass/_theme/configuration/icons.sass
@@ -54,12 +54,11 @@ $icons: map-merge($icons, ("arrow-down-line": "\ea4c"))
 $icons: map-merge($icons, ("arrow-up-line": "\ea76"))
 
 // Icons
-$icon-burger-margin-right: -12px
-$icon-close-margin-right: -12px
-$icon-toc-margin-right: -14px
-$icon-arrow-previous-margin-left: -18px // cf. testimonial
-$icon-social-margin-right: -14px
+$icon-burger-margin-right: -12px !default
+$icon-close-margin-right: -12px !default
+$icon-toc-margin-right: -14px !default
+$icon-arrow-previous-margin-left: -18px !default
+$icon-social-margin-right: -14px !default
 
 $icons-custom: false !default
 $icons-custom-font-family: false !default
-$icons-custom-size-ratio: false !default

--- a/assets/sass/_theme/design-system/layouts/cards.sass
+++ b/assets/sass/_theme/design-system/layouts/cards.sass
@@ -29,7 +29,7 @@
             padding-top: $spacing-4
             margin-top: auto
         a, p
-            transition: text-decoration-color .3s ease, color .3s ease
+            transition: text-decoration-color $color-duration ease, color $color-duration ease
         &:hover
             background-color: $background-hover
             &, a, p

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -13,9 +13,10 @@
                 opacity: 1
 
 @mixin icon($icon-name: '', $pseudo-element: before, $non-breaking: false)
+    $icon-code: map-get($icons, $icon-name)
     &::#{$pseudo-element}
-        content: map-get($icons, $icon-name)
-        content: map-get($icons, $icon-name) #{/ ""} // Add ‘ / ""‘ to hide from screen reader
+        content: $icon-code
+        content: $icon-code #{/ ""} // Add ‘ / ""‘ to hide from screen reader
         font-family: 'Icon'
         font-style: normal
         font-variant: normal
@@ -23,12 +24,17 @@
         line-height: 1
         speak: never
         text-transform: none
+        @if $icons-custom
+            $icon-custom-code: map-get($icons-custom, $icon-name)
+            @if $icon-custom-code
+                font-family: $icons-custom-font-family
+                $icon-code: $icon-custom-code
         @if $non-breaking
             display: inline
             @if $pseudo-element == "after"
-                content: " #{map-get($icons, $icon-name)}"
+                content: " #{$icon-code}"
             @if $pseudo-element == "before"
-                content: "#{map-get($icons, $icon-name)} "
+                content: "#{$icon-code} "
         @content // TODO : important de documenter ça
 
 @mixin icon-block($icon-name: '', $pseudo-element: before, $non-breaking: false)

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -15,8 +15,6 @@
 @mixin icon($icon-name: '', $pseudo-element: before, $non-breaking: false)
     $icon-code: map-get($icons, $icon-name)
     &::#{$pseudo-element}
-        content: $icon-code
-        content: $icon-code #{/ ""} // Add ‘ / ""‘ to hide from screen reader
         font-family: 'Icon'
         font-style: normal
         font-variant: normal
@@ -29,12 +27,17 @@
             @if $icon-custom-code
                 font-family: $icons-custom-font-family
                 $icon-code: $icon-custom-code
+                @if $icons-custom-size-ratio
+                    font-size: #{$icons-custom-size-ratio}em
         @if $non-breaking
             display: inline
             @if $pseudo-element == "after"
                 content: " #{$icon-code}"
             @if $pseudo-element == "before"
                 content: "#{$icon-code} "
+        @else
+            content: $icon-code
+            content: $icon-code #{/ ""} // Add ‘ / ""‘ to hide from screen reader
         @content // TODO : important de documenter ça
 
 @mixin icon-block($icon-name: '', $pseudo-element: before, $non-breaking: false)

--- a/assets/sass/_theme/utils/icons.sass
+++ b/assets/sass/_theme/utils/icons.sass
@@ -27,8 +27,6 @@
             @if $icon-custom-code
                 font-family: $icons-custom-font-family
                 $icon-code: $icon-custom-code
-                @if $icons-custom-size-ratio
-                    font-size: #{$icons-custom-size-ratio}em
         @if $non-breaking
             display: inline
             @if $pseudo-element == "after"


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Pouvoir overrider certaines icônes du thème, et cela, sans avoir à préciser tous les sélecteurs concernés par l'icône à remplacer : 

Par exemple : 
```
$icons-custom-font-family: "my-custom-icon-font-family-name"

$icons-custom: ()
// Override de la flèche pointant la droite avec le code typo de la font icon custom
$icons-custom: map-merge($icons-custom, ("arrow-right-line": "\ea6c"))
```


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

