### PR TITLE
Sous-titre dans la section des offres d'emplois

### DIFF
--- a/layouts/_partials/jobs/section/hero.html
+++ b/layouts/_partials/jobs/section/hero.html
@@ -1,4 +1,5 @@
-{{- $title := or .Params.header_text .Title -}}
+{{ $title := partial "header/helpers/GetTitle" . }}
+
 {{- partial "header/hero.html" (dict
   "title" $title
   "image" .Params.image


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il manquait le sous-titre sur la section des offres d'emplois : https://www.campusartmediterranee.fr/recrutement/

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site (optionnel)

`https://www.campusartmediterranee.fr/recrutement/`

## Screenshots

<img width="1469" height="452" alt="Capture d’écran 2026-04-14 à 14 08 32" src="https://github.com/user-attachments/assets/db06bb6a-5a01-4c09-84ef-f70cb5d58145" />
