### PR TITLE
Organisations : rich text pour le texte de présentation

### DIFF
--- a/layouts/_partials/organizations/single/presentation.html
+++ b/layouts/_partials/organizations/single/presentation.html
@@ -1,5 +1,4 @@
-{{ $text := partial "helpers/text/GetFromHTML" .Params.text }}
-{{ with $text }}
+{{ with .Params.text }}
   <div class="organization-presentation rich-text">
     {{ safeHTML . }}
   </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

La présentation d'une organisation ne prend pas en compte le rich text : 

<img width="1313" height="567" alt="Capture d’écran 2026-04-16 à 12 36 16" src="https://github.com/user-attachments/assets/4c99f8e1-c939-4791-963e-3c425662deff" />
<img width="1280" height="218" alt="Capture d’écran 2026-04-16 à 12 39 49" src="https://github.com/user-attachments/assets/82bf9a94-9644-48ac-baf7-9f7d7a07ccd7" />
## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1314/fr/organisations/noesya/`

## URL de test du site EPV

`http://localhost:1313/fr/organisations/alelor/`

## Screenshots

<img width="1270" height="689" alt="Capture d’écran 2026-04-16 à 12 36 27" src="https://github.com/user-attachments/assets/c078495e-3b4a-4273-9ac4-308b65359572" />
<img width="1234" height="163" alt="Capture d’écran 2026-04-16 à 12 39 58" src="https://github.com/user-attachments/assets/7006db70-75b6-4eb0-8510-a6b5b23e4273" />