### PR TITLE
Ordonner les organisations alphabétiquement

### DIFF
--- a/layouts/_partials/commons/section/helpers/IsFirstPage.html
+++ b/layouts/_partials/commons/section/helpers/IsFirstPage.html
@@ -1,5 +1,5 @@
 {{ $is_first_page := false }}
-{{ $paginator := .Paginate .Pages }}
+{{ $paginator := .Paginator }}
 
 {{ if $paginator }}
   {{ if eq $paginator.PageNumber 1 }}

--- a/layouts/_partials/commons/section/helpers/IsFirstPage.html
+++ b/layouts/_partials/commons/section/helpers/IsFirstPage.html
@@ -1,5 +1,5 @@
 {{ $is_first_page := false }}
-{{ $paginator := .Paginator }}
+{{ $paginator := .Paginate .Pages }}
 
 {{ if $paginator }}
   {{ if eq $paginator.PageNumber 1 }}

--- a/layouts/_partials/organizations/partials/organizations.html
+++ b/layouts/_partials/organizations/partials/organizations.html
@@ -1,13 +1,12 @@
 {{ $options := site.Params.organizations.index.options }}
 {{ $layout := "grid" }}
-{{ $paginator := .Paginate ( .Pages | uniq ) }}
 
-{{ if not $paginator.Pages }}
+{{ if not .Pages }}
   {{ $is_term := eq .Kind "term" }}
   <p>{{ i18n (cond $is_term "categories.no_organization" "organizations.none") }}</p>
 {{ else }}
   <ul class="organizations organizations--grid {{- if $options.summary }} with-summaries {{- end }}">
-    {{ range $paginator.Pages }}
+    {{ range .Pages }}
       <li>
         {{ partial "organizations/partials/organization.html" (dict
           "organization" .

--- a/layouts/_partials/organizations/partials/organizations.html
+++ b/layouts/_partials/organizations/partials/organizations.html
@@ -1,12 +1,13 @@
 {{ $options := site.Params.organizations.index.options }}
 {{ $layout := "grid" }}
+{{ $paginator := partial "organizations/section/helpers/GetPaginator" . }}
 
-{{ if not .Pages }}
+{{ if not $paginator.Pages }}
   {{ $is_term := eq .Kind "term" }}
   <p>{{ i18n (cond $is_term "categories.no_organization" "organizations.none") }}</p>
 {{ else }}
   <ul class="organizations organizations--grid {{- if $options.summary }} with-summaries {{- end }}">
-    {{ range .Pages }}
+    {{ range $paginator.Pages }}
       <li>
         {{ partial "organizations/partials/organization.html" (dict
           "organization" .

--- a/layouts/_partials/organizations/section.html
+++ b/layouts/_partials/organizations/section.html
@@ -1,10 +1,4 @@
-{{- $is_organizations_block_present := false -}}
-
-{{ range .Params.contents }}
-  {{- if eq .template "organizations" -}}
-    {{- $is_organizations_block_present = true -}}
-  {{ end }}
-{{ end }}
+{{ $paginator := partial "organizations/section/helpers/GetPaginator" . }}
 
 {{ partial "organizations/section/hero.html" . }}
 
@@ -14,7 +8,7 @@
     "with_container" true
   ) }}
 
-  {{ if partial "commons/section/helpers/IsFirstPage" . }}
+  {{ if eq $paginator.PageNumber 1 }}
     {{ partial "toc/container.html" (dict
       "context" .
     ) }}
@@ -26,9 +20,9 @@
 
   {{ partial "taxonomies/section/container.html" . }}
 
-  {{- if not $is_organizations_block_present -}}
+  {{- if not ( partial "organizations/section/helpers/HasBlockOrganizations" . ) -}}
     <div class="container">
-      {{ partial "organizations/partials/organizations.html" . }}
+      {{ partial "organizations/partials/organizations.html" $paginator }}
       {{ partial "commons/section/pagination.html" . }}
     </div>
   {{ end }}

--- a/layouts/_partials/organizations/section.html
+++ b/layouts/_partials/organizations/section.html
@@ -22,7 +22,7 @@
 
   {{- if not ( partial "organizations/section/helpers/HasBlockOrganizations" . ) -}}
     <div class="container">
-      {{ partial "organizations/partials/organizations.html" $paginator }}
+      {{ partial "organizations/partials/organizations.html" . }}
       {{ partial "commons/section/pagination.html" . }}
     </div>
   {{ end }}

--- a/layouts/_partials/organizations/section/helpers/GetPaginator.html
+++ b/layouts/_partials/organizations/section/helpers/GetPaginator.html
@@ -1,0 +1,3 @@
+{{ $organizations := .Pages.ByTitle | uniq }}
+{{ $paginator := .Paginate $organizations }}
+{{ return $paginator }}

--- a/layouts/_partials/organizations/section/helpers/HasBlockOrganizations.html
+++ b/layouts/_partials/organizations/section/helpers/HasBlockOrganizations.html
@@ -1,0 +1,9 @@
+{{ $is_organizations_block_present := false }}
+
+{{ range .Params.contents }}
+  {{- if eq .template "organizations" -}}
+    {{- $is_organizations_block_present = true -}}
+  {{ end }}
+{{ end }}
+
+{{ return $is_organizations_block_present }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [x] Rangement

## Description

La doctrine pour les paginations doit être basée sur la création d'un helper `GetPaginator` et supprimer progressivement les appels du helper `IsFirstPage` qui créer lui même une pagination (ce qui empêche les overrides où des ordres définis en fonction des types d'objets). 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
