### PR TITLE
Classes standardisées pour les options des blocs

### DIFF
--- a/layouts/_partials/blocks/helpers/GetClass.html
+++ b/layouts/_partials/blocks/helpers/GetClass.html
@@ -14,6 +14,10 @@
   {{ $class = printf "%s block-%s--%s" $class .template .data.layout }}
 {{ end }}
 
+{{ if .data.layout }}
+  {{ $class = printf "%s layout--%s" $class .data.layout }}
+{{ end }}
+
 {{ range $key, $value := .data.options }}
   {{ $class = printf "%s option__%s--%v" $class $key $value }}
 {{ end }}

--- a/layouts/_partials/blocks/helpers/GetClass.html
+++ b/layouts/_partials/blocks/helpers/GetClass.html
@@ -15,7 +15,7 @@
 {{ end }}
 
 {{ range $key, $value := .data.options }}
-  {{ $class = printf "%s option__%s--%v" $class $key $value }}
+  {{ $class = printf "%s block--option-%s-%v" $class $key $value }}
 {{ end }}
 
 {{ if .html_class }}

--- a/layouts/_partials/blocks/helpers/GetClass.html
+++ b/layouts/_partials/blocks/helpers/GetClass.html
@@ -14,6 +14,10 @@
   {{ $class = printf "%s block-%s--%s" $class .template .data.layout }}
 {{ end }}
 
+{{ range $key, $value := .data.options }}
+  {{ $class = printf "%s option__%s--%v" $class $key $value }}
+{{ end }}
+
 {{ if .html_class }}
   {{ $class = printf "%s %s" $class .html_class }}
 {{ end }}

--- a/layouts/_partials/blocks/helpers/GetClass.html
+++ b/layouts/_partials/blocks/helpers/GetClass.html
@@ -14,10 +14,6 @@
   {{ $class = printf "%s block-%s--%s" $class .template .data.layout }}
 {{ end }}
 
-{{ if .data.layout }}
-  {{ $class = printf "%s layout--%s" $class .data.layout }}
-{{ end }}
-
 {{ range $key, $value := .data.options }}
   {{ $class = printf "%s option__%s--%v" $class $key $value }}
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Tous les blocs ont maintenant des classes de type : 
```html
block--option-contact-false
block--option-image-true
block--option-link-true
block--option-summary-true
```

L'usage dans le design system osuny est : 
```sass
.block-persons
    &--list
        &.block--option-contact-false
            @include in-page-without-sidebar
                .description
                    .person-role
                        width: columns(8)
```

Problématiques à prendre en compte : 
- [x] Nommage compréhensible
- [x] Pas d'effet de bord avec d'autres classes
- [x] Facile à utiliser en CSS
- [x] Pas trop de surcharge du poids de la page

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱