### PR TITLE
Organisation : utiliser le logo par défaut si le logo sur fond foncé n'est pas présent

### DIFF
--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -141,6 +141,8 @@
         .blocks
             margin-top: $spacing-5
         .taxonomies-container
+            &:first-child
+                margin-top: 0
             &:not(:first-child)
                 margin-top: $spacing-5
     @include media-breakpoint-down(md)

--- a/layouts/_partials/organizations/partials/logo.html
+++ b/layouts/_partials/organizations/partials/logo.html
@@ -1,9 +1,11 @@
 {{ if .Params.logo }}
   {{ $logo := index .Params "logo" }}
   {{ $logo_on_dark_background := index .Params "logo_on_dark_background" }}
+  {{ $class := "organization-logo--default" }}
 
   {{ if and site.Params.organizations.dark_logo_background $logo_on_dark_background }}
     {{ $logo = $logo_on_dark_background }}
+    {{ $class := "organization-logo--on-dark-background" }}
   {{ end }}
 
   <figure class="organization-logo"{{ with .Title }} role="figure" aria-label="{{ . }}"{{ end }}>

--- a/layouts/_partials/organizations/partials/logo.html
+++ b/layouts/_partials/organizations/partials/logo.html
@@ -8,7 +8,7 @@
     {{ $class = "organization-logo--on-dark-background" }}
   {{ end }}
 
-  <figure class="organization-logo"{{ with .Title }} role="figure" aria-label="{{ . }}"{{ end }}>
+  <figure class="organization-logo {{ $class }}"{{ with .Title }} role="figure" aria-label="{{ . }}"{{ end }}>
     {{ partial "commons/image.html" (dict
       "image" $logo
       "alt" .Title

--- a/layouts/_partials/organizations/partials/logo.html
+++ b/layouts/_partials/organizations/partials/logo.html
@@ -1,11 +1,14 @@
 {{ if .Params.logo }}
-  {{ $logo_index := "logo" }}
-  {{ if site.Params.organizations.dark_logo_background }}
-    {{ $logo_index = "logo_on_dark_background" }}
+  {{ $logo := index .Params "logo" }}
+  {{ $logo_on_dark_background := index .Params "logo_on_dark_background" }}
+
+  {{ if and site.Params.organizations.dark_logo_background $logo_on_dark_background }}
+    {{ $logo = $logo_on_dark_background }}
   {{ end }}
+
   <figure class="organization-logo"{{ with .Title }} role="figure" aria-label="{{ . }}"{{ end }}>
     {{ partial "commons/image.html" (dict
-      "image" (index .Params $logo_index)
+      "image" $logo
       "alt" .Title
       "sizes" site.Params.image_sizes.sections.organizations.logo
     ) }}

--- a/layouts/_partials/organizations/partials/logo.html
+++ b/layouts/_partials/organizations/partials/logo.html
@@ -5,7 +5,7 @@
 
   {{ if and site.Params.organizations.dark_logo_background $logo_on_dark_background }}
     {{ $logo = $logo_on_dark_background }}
-    {{ $class := "organization-logo--on-dark-background" }}
+    {{ $class = "organization-logo--on-dark-background" }}
   {{ end }}
 
   <figure class="organization-logo"{{ with .Title }} role="figure" aria-label="{{ . }}"{{ end }}>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Cela permet d'éviter l'absence de logo si le logo sur fond noir n'est pas rempli.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
