### PR TITLE
Ordonner les timeslots par courant, futur et archivés

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -304,24 +304,25 @@ events:
   count:
     one: "1 event"
     other: "{{ .Count }} events"
-  item:
-    federated: "Event from <span>{{ . }}</span>"
-  more_dates: Show all dates
-  none: No event
-  next: Next event
-  previous: Previous event
   from:
     day: From day
     hour: From hour
+  item:
+    federated: "Event from <span>{{ . }}</span>"
+  more_dates: Show all dates
+  next: Next event
+  none: No event
+  passed: passed event
+  previous: Previous event
   see_all_in_program: See all program's events
   title: Events
   to:
     day: To day
     hour: To hour
   status:
+    archive: Passed
     current: Now
     future: Soon
-    archive: Passed
   unique_day: Date
 exhibitions:
   archives: Previous exhibitions archive

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -310,18 +310,19 @@ events:
   item:
     federated: "Événement du réseau <span>{{ . }}</span>"
   more_dates: Afficher toutes les dates
-  none: Aucun événement
   next: Événement suivant
+  none: Aucun événement
   part_of: Cet événement fait partie de
+  passed: événement passé
   previous: Événement précédent
-  see_all_in_program: Voir tous les événements de la formation
-  title: Événements
   regular_event: Événement régulier
+  see_all_in_program: Voir tous les événements de la formation
   see_programme: Accéder au programme
   status:
+    archive: Archive
     current: En cours
     future: À venir
-    archive: Archive
+  title: Événements
   unique_day: Date
   year:
     anchor: Accéder aux événements

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -251,6 +251,7 @@ events:
   hour: Hora
   none: Nenhum evento
   next: Próximo evento
+  passed: evento passado
   previous: Evento anterior
   from:
     day: Data de início

--- a/layouts/_partials/commons/agenda/dates/timeslots.html
+++ b/layouts/_partials/commons/agenda/dates/timeslots.html
@@ -1,30 +1,16 @@
 {{ $title := .Title }}
 {{ with .Params.time_slots }}
+  {{ $passed_time_slots := where . "status" "eq" "archive" }}
+  {{ $future_and_current_time_slots := where . "status" "in" (slice "future" "current") }}
+  {{ $ordered_time_slots := $future_and_current_time_slots | append $passed_time_slots }}
+
   <ul id="all-dates" class="extendable-list">
-    {{ range $index, $time_slot := . }}
-      <li class="event-time-slot" itemprop="subEvent" itemscope itemtype="https://schema.org/Event">
-        <meta itemprop="name" content="{{ $title }}">
-        {{ $event_date := $time_slot.start.date | time.Format site.Params.events.single.time_slots.date_format }}
-        <span class="date" itemprop="startDate" content="{{ .start.datetime }}">{{ $event_date | strings.FirstUpper }}</span>
-        <p class="hours">
-          {{ $time_format := ( i18n "commons.time_format" ) }}
-          {{ if $time_slot.start.datetime }}
-            <time datetime="{{ .start.time }}">{{ $time_slot.start.datetime | time.Format $time_format }}</time>
-          {{ end }}
-          {{ if $time_slot.end.datetime }}
-            <time datetime="{{ .end.time }}">{{ $time_slot.end.datetime | time.Format $time_format }}</time>
-          {{ end }}
-        </p>
-        {{ with $time_slot.place }}
-          <span class="location" itemprop="location">{{ . }}</span>
-        {{ end }}
-        {{ if ne .status "archive" }}
-          {{ partial "commons/agenda/dates/dropdown-calendar.html" (dict
-            "index" $index
-            "calendar_links" $time_slot.add_to_calendar
-          ) }}
-        {{ end }}
-      </li>
+    {{ range $index, $time_slot := $ordered_time_slots }}
+      {{ partial "commons/agenda/dates/timeslots/timeslot.html" (dict
+        "time_slot" $time_slot
+        "title" $title
+        "index" $index
+      ) }}
     {{ end }}
   </ul>
 {{ end }}

--- a/layouts/_partials/commons/agenda/dates/timeslots/timeslot.html
+++ b/layouts/_partials/commons/agenda/dates/timeslots/timeslot.html
@@ -1,0 +1,27 @@
+{{ $title := .title }}
+{{ $index := .index }}
+{{ with .time_slot }}
+  <li class="event-time-slot event-time-slot--{{ .status }}" itemprop="subEvent" itemscope itemtype="https://schema.org/Event">
+    <meta itemprop="name" content="{{ $title }}">
+    {{ $event_date := .start.date | time.Format site.Params.events.single.time_slots.date_format }}
+    <span class="date" itemprop="startDate" content="{{ .start.datetime }}">{{ $event_date | strings.FirstUpper }}</span>
+    <p class="hours">
+      {{ $time_format := ( i18n "commons.time_format" ) }}
+      {{ if .start.datetime }}
+        <time datetime="{{ .start.time }}">{{ .start.datetime | time.Format $time_format }}</time>
+      {{ end }}
+      {{ if .end.datetime }}
+        <time datetime="{{ .end.time }}">{{ .end.datetime | time.Format $time_format }}</time>
+      {{ end }}
+    </p>
+    {{ with .place }}
+      <span class="location" itemprop="location">{{ . }}</span>
+    {{ end }}
+    {{ if ne .status "archive" }}
+      {{ partial "commons/agenda/dates/dropdown-calendar.html" (dict
+        "index" $index
+        "calendar_links" .add_to_calendar
+      ) }}
+    {{ end }}
+  </li>
+{{ end }}

--- a/layouts/_partials/commons/agenda/dates/timeslots/timeslot.html
+++ b/layouts/_partials/commons/agenda/dates/timeslots/timeslot.html
@@ -22,6 +22,8 @@
         "index" $index
         "calendar_links" .add_to_calendar
       ) }}
+    {{ else }}
+      <p class="small">{{ i18n "events.passed" }}</p>
     {{ end }}
   </li>
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [x] Rangement

## Description

Afficher les timeslots passés après les courants et futurs.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/gaitelyrique-www/issues/144#issuecomment-4281014629


## Screenshots

### Avant :

<img width="1982" height="483" alt="image" src="https://github.com/user-attachments/assets/7e40c75f-b21f-47b6-b5ce-2ee61305c1c5" />


### Après : 

<img width="1904" height="532" alt="image" src="https://github.com/user-attachments/assets/6408d128-2821-402f-87f5-5bdc42a7ef47" />




