### PR TITLE
Offres d'emploi : tri par date

### DIFF
--- a/layouts/_partials/jobs/partials/jobs.html
+++ b/layouts/_partials/jobs/partials/jobs.html
@@ -4,7 +4,7 @@
 {{ $heading_level := 2 }}
 
 <ul class="jobs jobs--{{- $layout }}">
-  {{ range $jobs }}
+  {{ range sort $jobs ".Params.dates.from.day" "desc" }}
     <li>
       {{ partial "jobs/partials/job.html" (dict
         "job" .

--- a/layouts/_partials/jobs/partials/jobs.html
+++ b/layouts/_partials/jobs/partials/jobs.html
@@ -2,9 +2,10 @@
 {{ $layout := default site.Params.jobs.index.layout }}
 {{ $options := default site.Params.jobs.index.options }}
 {{ $heading_level := 2 }}
+{{ $paginator := partial "jobs/section/helpers/GetPaginator" . }}
 
 <ul class="jobs jobs--{{- $layout }}">
-  {{ range sort $jobs ".Params.dates.from.day" "desc" }}
+  {{ range $paginator.Pages }}
     <li>
       {{ partial "jobs/partials/job.html" (dict
         "job" .

--- a/layouts/_partials/jobs/section.html
+++ b/layouts/_partials/jobs/section.html
@@ -1,11 +1,14 @@
+{{ $paginator := partial "jobs/section/helpers/GetPaginator" . }}
+
 {{ partial "jobs/section/hero.html" . }}
+
 <div class="document-content">
   {{ partial "jobs/section/summary.html" (dict
     "with_container" true
     "context" .
   ) }}
 
-  {{ if partial "commons/section/helpers/IsFirstPage" . }}
+  {{ if eq $paginator.PageNumber 1 }}
     {{ partial "contents/list.html" (dict
       "context" .
       "contents" .Params.contents

--- a/layouts/_partials/jobs/section/helpers/GetPaginator.html
+++ b/layouts/_partials/jobs/section/helpers/GetPaginator.html
@@ -1,0 +1,3 @@
+{{ $jobs := sort .Pages "Params.dates.from.day" "desc" | uniq }}
+{{ $paginator := .Paginate $jobs }}
+{{ return $paginator }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

On s'appuie sur `.Params.dates.from.day` pour obtenir la date et ranger les offres par ordre de début (celles qui vont commencer dans le futur en premier).

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`https://example.osuny.org/fr/offres-d-emploi/`

## URL de test du site paysHLV
http://localhost:1313/offres-d-emploi/