### PR TITLE
Bloc événement : afficher les heures hors du mode "selection"

### DIFF
--- a/assets/sass/_theme/sections/events/layouts.sass
+++ b/assets/sass/_theme/sections/events/layouts.sass
@@ -85,6 +85,9 @@
                 &-schedule
                     margin-top: $spacing-1
                     margin-bottom: $spacing-2
+                    display: flex
+                    align-items: baseline
+                    gap: $spacing-3
                 &-hours
                     display: inline
                 .media

--- a/layouts/_partials/blocks/templates/agenda.html
+++ b/layouts/_partials/blocks/templates/agenda.html
@@ -1,9 +1,9 @@
-{{- $block := .block }}
+{{ $block := .block }}
 {{ $block_class := partial "blocks/helpers/GetClass" .block }}
 {{ with .block.data }}
-  {{- $options := .options -}}
-  {{- $layout := .layout | default "list" -}}
-  
+  {{ $options := .options }}
+  {{ $layout := .layout | default "list" }}
+  {{ $mode := .mode }}
   <div class="{{ $block_class }}">
     <div class="container">
       <div class="block-content">
@@ -16,6 +16,7 @@
                 <li itemscope itemtype="https://schema.org/Event">
                   {{ partial "events/partials/event.html" (dict
                     "event" .
+                    "mode" $mode
                     "layout" $layout
                     "options" $options
                     "heading_level" $block.ranks.children

--- a/layouts/_partials/commons/item/schedule.html
+++ b/layouts/_partials/commons/item/schedule.html
@@ -2,7 +2,7 @@
 {{ $time_slot := .time_slot }}
 {{ $on_two_lines := .on_two_lines }}
 {{ $type := .type }}
-{{ $is_repeating := .is_repeating }} {{/* used in context commons/item/schedule/dates.html  */}}
+{{ $is_repeating := .is_repeating }}
 {{ $with_hours := .with_hours }}
 
 {{ if or $dates.computed.short $dates.computed.two_lines.short $time_slot }}

--- a/layouts/_partials/commons/item/schedule.html
+++ b/layouts/_partials/commons/item/schedule.html
@@ -1,6 +1,5 @@
 {{ $dates := .dates }}
 {{ $time_slot := .time_slot }}
-{{ $is_repeating := .is_repeating }}
 {{ $on_two_lines := .on_two_lines }}
 {{ $with_hours := .with_hours }}
 {{ $type := .type }}
@@ -13,7 +12,7 @@
       "context" .
     ) }}
 
-    {{- if and $with_hours $time_slot (not $is_repeating) }}
+    {{- if and $with_hours $time_slot }}
       {{ partial "commons/item/schedule/hours.html" (dict
         "hours" $time_slot
         "type" $type

--- a/layouts/_partials/commons/item/schedule.html
+++ b/layouts/_partials/commons/item/schedule.html
@@ -1,22 +1,26 @@
 {{ $dates := .dates }}
 {{ $time_slot := .time_slot }}
 {{ $on_two_lines := .on_two_lines }}
-{{ $with_hours := .with_hours }}
 {{ $type := .type }}
-{{ $date_format := index site.Params (pluralize $type) "date_format" }}
+{{ $is_repeating := .is_repeating }} {{/* used in context commons/item/schedule/dates.html  */}}
+{{ $with_hours := .with_hours }}
 
 {{ if or $dates.computed.short $dates.computed.two_lines.short $time_slot }}
   <div class="{{ $type }}-schedule">
     {{ partial "commons/item/schedule/dates.html" (dict
       "type" $type
+      "dates" .dates
+      "time_slot" .time_slot
+      "on_two_lines" .on_two_lines
+      "is_repeating" .is_repeating
       "context" .
     ) }}
 
-    {{- if and $with_hours $time_slot }}
+    {{ if and $with_hours $time_slot }}
       {{ partial "commons/item/schedule/hours.html" (dict
         "hours" $time_slot
         "type" $type
       ) }}
-    {{ end -}}
+    {{ end }}
   </div>
 {{ end }}

--- a/layouts/_partials/commons/item/schedule/dates.html
+++ b/layouts/_partials/commons/item/schedule/dates.html
@@ -1,4 +1,4 @@
+{{ $formated_date := partial "commons/item/helpers/GetFormatedDate.html" . }}
 <p class="{{ .type }}-dates">
-  {{ $formated_date := partial "commons/item/helpers/GetFormatedDate.html" .context }}
   {{ safeHTML $formated_date }}
 </p>

--- a/layouts/_partials/events/partials/event/datetime.html
+++ b/layouts/_partials/events/partials/event/datetime.html
@@ -6,11 +6,12 @@
 {{ end }}
 
 {{ if .options.dates }}
+  {{ $with_hours := and (eq .mode "all") (ne .layout "agenda") }}
   {{ partial "events/partials/event/datetime/schedule.html" (dict 
     "dates" .event.Params.dates
     "time_slot" .event.Params.current_time_slot
     "time_slots" .event.Params.time_slots
-    "with_hours" (ne .layout "agenda")
+    "with_hours" $with_hours
   ) }}
 {{ end }}
 

--- a/layouts/_partials/events/partials/event/datetime.html
+++ b/layouts/_partials/events/partials/event/datetime.html
@@ -6,7 +6,7 @@
 {{ end }}
 
 {{ if .options.dates }}
-  {{ $with_hours := and (eq .mode "all") (ne .layout "agenda") }}
+  {{ $with_hours := and (ne .mode "selection") (ne .layout "agenda") }}
   {{ partial "events/partials/event/datetime/schedule.html" (dict 
     "dates" .event.Params.dates
     "time_slot" .event.Params.current_time_slot

--- a/layouts/_partials/events/partials/event/datetime.html
+++ b/layouts/_partials/events/partials/event/datetime.html
@@ -6,12 +6,13 @@
 {{ end }}
 
 {{ if .options.dates }}
-  {{ $with_hours := and (ne .mode "selection") (ne .layout "agenda") }}
   {{ partial "events/partials/event/datetime/schedule.html" (dict 
     "dates" .event.Params.dates
     "time_slot" .event.Params.current_time_slot
     "time_slots" .event.Params.time_slots
-    "with_hours" $with_hours
+    "layout" .layout
+    "mode" .mode
+    "context" .
   ) }}
 {{ end }}
 

--- a/layouts/_partials/events/partials/event/datetime/schedule.html
+++ b/layouts/_partials/events/partials/event/datetime/schedule.html
@@ -2,7 +2,6 @@
   "dates" .dates
   "time_slot" .time_slot
   "on_two_lines" false
-  "is_repeating" (gt .time_slots 1)
   "type" "event"
   "with_hours" .with_hours
 ) }}

--- a/layouts/_partials/events/partials/event/datetime/schedule.html
+++ b/layouts/_partials/events/partials/event/datetime/schedule.html
@@ -1,7 +1,16 @@
+{{ $is_selection := eq .mode "selection" }}
+
+{{/*  show hours if outside agenda and not in selection mode  */}}
+{{ $with_hours := and (ne .layout "agenda") (not $is_selection) }}
+
+{{/*  ignore repeating state if event is in selection mode  */}}
+{{ $is_repeating := (and (gt .time_slots 1) (not $is_selection)) }}
+
 {{ partial "commons/item/schedule.html" (dict
   "dates" .dates
   "time_slot" .time_slot
   "on_two_lines" false
   "type" "event"
-  "with_hours" .with_hours
+  "is_repeating" $is_repeating
+  "with_hours" $with_hours
 ) }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

https://developers.osuny.org/docs/theme/architecture/events-block-timeslots/

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

