### PR TITLE
Événements : masquer les timeslots archivés dans la liste des dates

### DIFF
--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -219,7 +219,9 @@
                                 opacity: 1
         .event-summary + ul
             margin-top: $spacing-3
-        // Hide li childs after 6th one (included)
+        // Hide li childs:
+        // - after 6th one (included)
+        // - if its status is 'archive'
         ul.truncated-list
             li:nth-child(n+7),
             li.event-time-slot--archive

--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -221,7 +221,8 @@
             margin-top: $spacing-3
         // Hide li childs after 6th one (included)
         ul.truncated-list
-            li:nth-child(n+7)
+            li:nth-child(n+7),
+            li.event-time-slot--archive
                 display: none
         ul:not(.truncated-list)
             + .btn


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Actuellement, la liste des timeslots affiche à la fois des événements à venir, actuels ou archivés.
L'idée est de basculer les archives dans la partie masquée de la liste

On se retrouve donc avec 2 types d'éléments masqués : 
- les timeslots à partir du 6e
- les timeslots archives

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1493

## URL de test sur example.osuny.org

`http://localhost:1313/fr/agenda/2024/anne-charlotte-finel-respiro/`

## URL de test du site GL
`http://localhost:1313/agenda/2026/distributions-etudiantes/`
`http://localhost:1313/agenda/2026/yadu-yoga/`
`http://localhost:1313/agenda/2026/ping-therapie/`

## Screenshots

<img width="1468" height="543" alt="Capture d’écran 2026-04-27 à 10 10 38" src="https://github.com/user-attachments/assets/3aa1af16-76fe-474a-a5eb-0ff7f83765f3" />
<img width="1468" height="724" alt="Capture d’écran 2026-04-27 à 10 10 29" src="https://github.com/user-attachments/assets/e4756245-7891-4ecf-85ca-811ce2a088ef" />

Avant : 
<img width="1467" height="414" alt="Capture d’écran 2026-04-27 à 10 23 13" src="https://github.com/user-attachments/assets/ca071f45-6409-4507-a1ad-33466dbbd656" />

Après : 
<img width="1467" height="366" alt="Capture d’écran 2026-04-27 à 10 23 07" src="https://github.com/user-attachments/assets/3fcc1339-2aaa-47a8-b7e5-6f0fbc11b6c6" />
