### PR TITLE
Bloc définitions : alignement du contenu

### DIFF
--- a/assets/sass/_theme/blocks/definitions.sass
+++ b/assets/sass/_theme/blocks/definitions.sass
@@ -35,7 +35,6 @@
     @include in-page-without-sidebar
         .definitions
             details
-                p
+                .definition-content
                     padding-left: columns(4)
                     margin-left: var(--grid-gutter)
-

--- a/layouts/_partials/blocks/templates/definitions.html
+++ b/layouts/_partials/blocks/templates/definitions.html
@@ -11,7 +11,7 @@
         <div class="definitions">
           {{ range $index, $element := .elements }}
             {{ $id := printf "block-%s-element-%d" $html_id $index }}
-            <details id="{{ $id }}" itemscope itemtype="https://schema.org/DefinedTerm">
+            <details id="{{ $id }}" class="definition" itemscope itemtype="https://schema.org/DefinedTerm">
               <summary itemprop="name" aria-controls="{{ $id }}" aria-expanded="false">{{ $element.title | safeHTML }}</summary>
               <div itemprop="description" class="definition-content">{{ safeHTML $element.description }}</div>
             </details>

--- a/layouts/_partials/blocks/templates/definitions.html
+++ b/layouts/_partials/blocks/templates/definitions.html
@@ -13,7 +13,7 @@
             {{ $id := printf "block-%s-element-%d" $html_id $index }}
             <details id="{{ $id }}" itemscope itemtype="https://schema.org/DefinedTerm">
               <summary itemprop="name" aria-controls="{{ $id }}" aria-expanded="false">{{ $element.title | safeHTML }}</summary>
-              <div itemprop="description">{{ safeHTML $element.description }}</div>
+              <div itemprop="description" class="definition-content">{{ safeHTML $element.description }}</div>
             </details>
           {{ end }}
         </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les listes sont ferrées à gauche au lieu d'avoir un padding, car le sélecteur est `details p`

- Ajout d'une class `definition-content` -> va dans le sens du thème mais le bloc est sobre
- Déplacement du padding/margin sur le contenant du texte

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1350

## URL de test sur example.osuny.org

`http://localhost:1313/fr/blocks/blocks-techniques/definitions/#plusieurs-definitions-texte-avec-et-sans-titre`

## Screenshots
<img width="1323" height="474" alt="Capture d’écran 2026-04-27 à 15 34 50" src="https://github.com/user-attachments/assets/1afe40c8-7dd1-4199-9ebb-f02ca47766ab" />