### PR TITLE
Tri par ordre alphabétique des formations

### DIFF
--- a/layouts/_partials/diplomas/single/programs.html
+++ b/layouts/_partials/diplomas/single/programs.html
@@ -6,7 +6,7 @@
 {{ end }}
 <div class="container">
   <ol class="{{ $class }}">
-    {{ range .Pages }}
+    {{ range .Pages.ByTitle }}
       {{ partial "programs/partials/program.html" (dict
         "program" .
         "heading_level" 2

--- a/layouts/_partials/programs/section/programs.html
+++ b/layouts/_partials/programs/section/programs.html
@@ -7,8 +7,9 @@
   {{/* et pas non plus les pages enfants (parcours) */}}
   {{ $programs = where $programs "Params.parent" "eq" nil }}
   {{ $layout := site.Params.programs.index.layout | default "list" }}
+
   <ol class="programs programs--{{ $layout }}">
-    {{- range $programs -}}
+    {{- range $programs.ByTitle -}}
       {{ partial "programs/partials/program.html" (dict 
         "program" .
         "heading_level" 2

--- a/layouts/_partials/sitemap/sections/children.html
+++ b/layouts/_partials/sitemap/sections/children.html
@@ -1,10 +1,19 @@
+{{ $pages := .items }}
+{{ $type := .type }}
+{{ if in (slice "persons" "organizations" "programs") $type }}
+  {{ $pages = sort $pages "Title" }}
+{{ end }}
+
 <ul>
-  {{ range . }}
+  {{ range $pages }}
     {{ if not .Params.ignore.in_sitemap }}
       <li>
         <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>
         {{ with .Pages }}
-          {{ partial "sitemap/sections/children.html" . }}
+          {{ partial "sitemap/sections/children.html" (dict
+            "items" .
+            "type" $type
+          ) }}
         {{ end }}
       </li>
     {{ end }}

--- a/layouts/_partials/sitemap/sections/children.html
+++ b/layouts/_partials/sitemap/sections/children.html
@@ -1,11 +1,11 @@
-{{ $pages := .items }}
+{{ $items := .items }}
 {{ $type := .type }}
 {{ if in (slice "persons" "organizations" "programs") $type }}
-  {{ $pages = sort $pages "Title" }}
+  {{ $items = $items.ByTitle }}
 {{ end }}
 
 <ul>
-  {{ range $pages }}
+  {{ range $items }}
     {{ if not .Params.ignore.in_sitemap }}
       <li>
         <a href="{{ .Permalink }}">{{ safeHTML .Title }}</a>

--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -4,7 +4,10 @@
     <li>
       <a href="{{ .Permalink }}">{{ .Title }}</a>
       {{ $events := where .RegularPagesRecursive "Params.dates.archive" false }}
-      {{ partial "sitemap/sections/children.html" $events }}
+      {{ partial "sitemap/sections/children.html" (dict 
+        "items" $events
+        "type" "events"
+      ) }}
     </li>
   {{ end }}
 </ul>

--- a/layouts/_partials/sitemap/sections/list.html
+++ b/layouts/_partials/sitemap/sections/list.html
@@ -16,7 +16,10 @@
         {{ if eq .Type "events" }}
           {{ partial "sitemap/sections/events.html" . }}
         {{ else }}
-          {{ partial "sitemap/sections/children.html" .Pages }}
+          {{ partial "sitemap/sections/children.html" (dict
+            "items" .Pages
+            "type" .Type
+          ) }}
         {{ end }}
       {{ end }}
     </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajustement de l'ordre des formations (index et dans un diplome), pour ordonner par titre.

- [x] Index des formations
- [x] Formations dans un diplôme
- [ ] Personnes dans le plan du site
- [ ] Organisations dans le plan du site 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1460

## URL de test sur example.osuny.org

`http://localhost:1313/fr/offre-de-formation/`
`http://localhost:1313/fr/diplomes/bachelor-universitaire-de-technologie/`