### PR TITLE
[A11Y] Gestion du focus de la toc

### DIFF
--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -19,6 +19,7 @@ window.osuny.TableOfContents = function (element) {
     this.sections = this.getSections();
     this.ctaTitle = document.querySelector('.toc-cta-title span');
     this.openerButton = document.querySelector('.toc-cta button');
+    this.closingButton = document.querySelector('.toc-content > button');
     this.togglers = document.querySelectorAll('.toc-cta button, .toc-container button');
     this.state = {
         opened: false,
@@ -93,6 +94,8 @@ window.osuny.TableOfContents.prototype.toggle = function (open) {
     var classAction = this.state.opened ? 'add' : 'remove',
         transitionDuration = this.state.opened ? 0 : this.getTransitionDuration();
 
+    
+    
     // TODO: refacto timeout and css transition
     setTimeout( function () {
         this.element.setAttribute('aria-hidden', !this.state.opened);
@@ -100,6 +103,11 @@ window.osuny.TableOfContents.prototype.toggle = function (open) {
 
     setTimeout( function () {
         this.element.classList[classAction](CLASSES.isOpened);
+        if (this.state.opened) {
+            this.closingButton.focus();
+        } else {
+            this.openerButton.focus();
+        }
     }.bind(this), 50);
 
     document.documentElement.classList[classAction](CLASSES.offcanvasOpened);

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -80,8 +80,7 @@ window.osuny.TableOfContents.prototype.listen = function () {
     window.addEventListener('scroll', this.update.bind(this));
     window.addEventListener('resize', this.resize.bind(this));
     window.addEventListener('click', this.clickOnBackground.bind(this));
-    window.addEventListener('keydown', this.pressEscape.bind(this));
-    window.addEventListener('keydown', this.checkFocusTrap.bind(this));
+    window.addEventListener('keydown', this.keyDown.bind(this));
 
     if (this.elements.buttonOpen) {
         this.elements.buttonOpen.addEventListener('click', this.open.bind(this));
@@ -174,21 +173,22 @@ window.osuny.TableOfContents.prototype.resize = function () {
 };
 
 window.osuny.TableOfContents.prototype.clickOnBackground = function (event) {
-    if (this.state.opened && event.target === document.body) {
+    if (!this.state.opened) {
+        return;
+    }
+    if (event.target === document.body) {
         this.closeAndFocusButtonOpen();
     }
 };
 
-window.osuny.TableOfContents.prototype.pressEscape = function (event) {
-    if (this.state.opened && (event.keyCode === 27 || event.key === 'Escape')) {
+window.osuny.TableOfContents.prototype.keyDown = function (event) {
+    if (!this.state.opened) {
+        return;
+    }
+    if (event.keyCode === 27 || event.key === 'Escape') {
         this.closeAndFocusButtonOpen();
     }
-};
-
-window.osuny.TableOfContents.prototype.checkFocusTrap = function (event) {
-    if (this.state.opened) {
-        focusTrap(event, this.elements.root, true);
-    }
+    focusTrap(event, this.elements.root, true);
 };
 
 window.osuny.page.registerComponent({

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -103,7 +103,9 @@ window.osuny.TableOfContents.prototype.open = function () {
     this.elements.root.setAttribute('aria-hidden', 'false');
     document.documentElement.classList.add(this.classes.offcanvasOpened);
     setTimeout( function () {
+        // Pour permettre l'animation d'apparition
         this.elements.root.classList.add(this.classes.isOpened);
+        // Pour éviter de donner le focus à un élément caché
         this.elements.buttonClose.focus();
     }.bind(this), 50);
 };

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -68,7 +68,7 @@ window.osuny.TableOfContents.prototype.listen = function () {
 
     this.links.forEach( function (links) {
         links.addEventListener('click', function () {
-            this.toggle(false);
+            this.toggle(false, true);
         }.bind(this));
     }.bind(this));
 
@@ -86,7 +86,7 @@ window.osuny.TableOfContents.prototype.listen = function () {
     }.bind(this));
 };
 
-window.osuny.TableOfContents.prototype.toggle = function (open) {
+window.osuny.TableOfContents.prototype.toggle = function (open, hasTarget) {
     if (!this.state.isOffcanvas) {
         return;
     }
@@ -94,8 +94,6 @@ window.osuny.TableOfContents.prototype.toggle = function (open) {
     var classAction = this.state.opened ? 'add' : 'remove',
         transitionDuration = this.state.opened ? 0 : this.getTransitionDuration();
 
-    
-    
     // TODO: refacto timeout and css transition
     setTimeout( function () {
         this.element.setAttribute('aria-hidden', !this.state.opened);
@@ -105,12 +103,14 @@ window.osuny.TableOfContents.prototype.toggle = function (open) {
         this.element.classList[classAction](CLASSES.isOpened);
         if (this.state.opened) {
             this.closingButton.focus();
-        } else {
+        }
+        if (!this.state.opened && !hasTarget) {
             this.openerButton.focus();
         }
     }.bind(this), 50);
 
     document.documentElement.classList[classAction](CLASSES.offcanvasOpened);
+
 };
 
 window.osuny.TableOfContents.prototype.getTransitionDuration = function () {

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -18,7 +18,7 @@ window.osuny.TableOfContents = function (element) {
         opened: false,
         currentId: null,
         currentLink: 0,
-        isOffcanvas: this.isOffcanvas()
+        isOffcanvas: null
     };
 
     this.classes = {
@@ -50,6 +50,7 @@ window.osuny.TableOfContents.prototype.getSections = function () {
 };
 
 window.osuny.TableOfContents.prototype.initializeAria = function () {
+    this.state.isOffcanvas = this.isOffcanvas()
     if (this.state.isOffcanvas) {
         this.element.setAttribute('aria-hidden', true);
     }
@@ -60,27 +61,16 @@ window.osuny.TableOfContents.prototype.isOffcanvas = function () {
 };
 
 window.osuny.TableOfContents.prototype.listen = function () {
-    window.addEventListener('scroll', this.update.bind(this), false);
-    window.addEventListener('resize', this.resize.bind(this), false);
+    window.addEventListener('scroll', this.update.bind(this));
+    window.addEventListener('resize', this.resize.bind(this));
+    window.addEventListener('click', this.clickOnBackground.bind(this));
+    window.addEventListener('keydown', this.pressEscape.bind(this));
 
     this.buttonOpen.addEventListener('click', this.open.bind(this));
     this.buttonClose.addEventListener('click', this.close.bind(this));
 
     this.links.forEach( function (link) {
         link.addEventListener('click', this.close.bind(this));
-    }.bind(this));
-
-    window.addEventListener('click', function (event) {
-        if (event.target === document.body) {
-            this.close();
-        }
-    }.bind(this));
-
-    window.addEventListener('keydown', function (event) {
-        if (event.keyCode === 27 || event.key === 'Escape') {
-            this.close();
-        }
-        focusTrap(event, this.element, this.state.opened);
     }.bind(this));
 };
 
@@ -168,6 +158,19 @@ window.osuny.TableOfContents.prototype.updateScrollspy = function (scroll) {
 
 window.osuny.TableOfContents.prototype.resize = function () {
     this.state.isOffcanvas = this.isOffcanvas();
+};
+
+window.osuny.TableOfContents.prototype.clickOnBackground = function (event) {
+    if (event.target === document.body) {
+        this.close();
+    }
+};
+
+window.osuny.TableOfContents.prototype.pressEscape = function (event) {
+    if (event.keyCode === 27 || event.key === 'Escape') {
+        this.close();
+    }
+    focusTrap(event, this.element, this.state.opened);
 };
 
 window.osuny.page.registerComponent({

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -65,6 +65,7 @@ window.osuny.TableOfContents.prototype.listen = function () {
     window.addEventListener('resize', this.resize.bind(this));
     window.addEventListener('click', this.clickOnBackground.bind(this));
     window.addEventListener('keydown', this.pressEscape.bind(this));
+    window.addEventListener('keydown', this.checkFocusTrap.bind(this));
 
     this.buttonOpen.addEventListener('click', this.open.bind(this));
     this.buttonClose.addEventListener('click', this.close.bind(this));
@@ -170,7 +171,12 @@ window.osuny.TableOfContents.prototype.pressEscape = function (event) {
     if (event.keyCode === 27 || event.key === 'Escape') {
         this.close();
     }
-    focusTrap(event, this.element, this.state.opened);
+};
+
+window.osuny.TableOfContents.prototype.checkFocusTrap = function (event) {
+    if (this.state.opened) {
+        focusTrap(event, this.element, this.state.opened);
+    }
 };
 
 window.osuny.page.registerComponent({

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -176,7 +176,7 @@ window.osuny.TableOfContents.prototype.pressEscape = function (event) {
 
 window.osuny.TableOfContents.prototype.checkFocusTrap = function (event) {
     if (this.state.opened) {
-        focusTrap(event, this.element, true);
+        focusTrap(event, this.elements.root, true);
     }
 };
 

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -98,9 +98,6 @@ window.osuny.TableOfContents.prototype.open = function () {
 };
 
 window.osuny.TableOfContents.prototype.close = function () {
-    if (!this.state.isOffcanvas) {
-        return;
-    }
     this.state.opened = false;
     this.element.classList.remove(this.classes.isOpened);
     this.buttonOpen.focus();

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -103,8 +103,7 @@ window.osuny.TableOfContents.prototype.toggle = function (open, hasTarget) {
         this.element.classList[classAction](CLASSES.isOpened);
         if (this.state.opened) {
             this.closingButton.focus();
-        }
-        if (!this.state.opened && !hasTarget) {
+        } else if (!hasTarget) {
             this.openerButton.focus();
         }
     }.bind(this), 50);

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -145,7 +145,7 @@ window.osuny.TableOfContents.prototype.activateLink = function (id) {
         if (link === currentLink) {
             link.classList.add(this.classes.linkActive);
             link.setAttribute('aria-current', 'true');
-            this.state.id = id;
+            this.state.currentId = id;
             this.state.currentLink = link;
         } else {
             link.classList.remove(this.classes.linkActive);

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -35,6 +35,7 @@ window.osuny.TableOfContents = function (element) {
 };
 
 // Initialisation
+
 window.osuny.TableOfContents.prototype.initializeSections = function () {
     var id,
         section,
@@ -59,6 +60,22 @@ window.osuny.TableOfContents.prototype.isOffcanvas = function () {
     return isMobile() || document.body.classList.contains(this.classes.fullWidth) || document.body.classList.contains(this.classes.offcanvas);
 };
 
+window.osuny.TableOfContents.prototype.getTransitionDuration = function () {
+    var style = getComputedStyle(this.elements.root),
+        property = style.getPropertyValue('transition-duration');
+        milliseconds = parseFloat(property.replace('s', '')) * 1000;
+    return milliseconds;
+};
+
+window.osuny.TableOfContents.prototype.getAbsoluteOffsetTop = function (element) {
+    var top = 0;
+    do {
+        top += element.offsetTop || 0;
+        element = element.offsetParent;
+    } while (element);
+    return top;
+};
+
 window.osuny.TableOfContents.prototype.listen = function () {
     window.addEventListener('scroll', this.update.bind(this));
     window.addEventListener('resize', this.resize.bind(this));
@@ -67,8 +84,7 @@ window.osuny.TableOfContents.prototype.listen = function () {
     window.addEventListener('keydown', this.checkFocusTrap.bind(this));
 
     this.elements.buttonOpen.addEventListener('click', this.open.bind(this));
-    this.elements.buttonClose.addEventListener('click', this.close.bind(this));
-
+    this.elements.buttonClose.addEventListener('click', this.closeAndFocusButtonOpen.bind(this));
     this.elements.links.forEach( function (link) {
         link.addEventListener('click', this.close.bind(this));
     }.bind(this));
@@ -92,42 +108,16 @@ window.osuny.TableOfContents.prototype.open = function () {
 window.osuny.TableOfContents.prototype.close = function () {
     this.state.opened = false;
     this.elements.root.classList.remove(this.classes.isOpened);
-    this.elements.buttonOpen.focus();
     document.documentElement.classList.remove(this.classes.offcanvasOpened);
     setTimeout( function () {
         this.elements.root.setAttribute('aria-hidden', true);
     }.bind(this), this.getTransitionDuration());
 };
 
-window.osuny.TableOfContents.prototype.getTransitionDuration = function () {
-    var style = getComputedStyle(this.elements.root),
-        property = style.getPropertyValue('transition-duration');
-        milliseconds = parseFloat(property.replace('s', '')) * 1000;
-    return milliseconds;
-};
-
-window.osuny.TableOfContents.prototype.update = function () {
-    var scroll = document.documentElement.scrollTop || document.body.scrollTop;
-    var id = null;
-    this.elements.sections.forEach(function (section) {
-        if (this.getAbsoluteOffsetTop(section) <= scroll + window.innerHeight / 2) {
-            id = section.id;
-        }
-    }.bind(this));
-
-    if (id && id !== this.state.currentId) {
-        this.activateLink(id);
-    }
-    this.updateScrollspy(scroll);
-};
-
-window.osuny.TableOfContents.prototype.getAbsoluteOffsetTop = function (element) {
-    var top = 0;
-    do {
-        top += element.offsetTop || 0;
-        element = element.offsetParent;
-    } while (element);
-    return top;
+// focus opener button, see: https://github.com/osunyorg/theme/issues/1015
+window.osuny.TableOfContents.prototype.closeAndFocusButtonOpen = function () {
+    this.close();
+    this.elements.buttonOpen.focus();
 };
 
 window.osuny.TableOfContents.prototype.activateLink = function (id) {
@@ -146,6 +136,20 @@ window.osuny.TableOfContents.prototype.activateLink = function (id) {
     }.bind(this));
 };
 
+window.osuny.TableOfContents.prototype.update = function () {
+    var scroll = document.documentElement.scrollTop || document.body.scrollTop;
+    var id = null;
+    this.elements.sections.forEach(function (section) {
+        if (this.getAbsoluteOffsetTop(section) <= scroll + window.innerHeight / 2) {
+            id = section.id;
+        }
+    }.bind(this));
+
+    if (id && id !== this.state.currentId) {
+        this.activateLink(id);
+    }
+    this.updateScrollspy(scroll);
+};
 
 window.osuny.TableOfContents.prototype.updateScrollspy = function (scroll) {
     var container = this.state.isOffcanvas ? this.elements.nav : this.elements.content;
@@ -164,13 +168,13 @@ window.osuny.TableOfContents.prototype.resize = function () {
 
 window.osuny.TableOfContents.prototype.clickOnBackground = function (event) {
     if (event.target === document.body) {
-        this.close();
+        this.closeAndFocusButtonOpen();
     }
 };
 
 window.osuny.TableOfContents.prototype.pressEscape = function (event) {
     if (event.keyCode === 27 || event.key === 'Escape') {
-        this.close();
+        this.closeAndFocusButtonOpen();
     }
 };
 

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -3,14 +3,6 @@ import { focusTrap } from '../../utils/focus-trap';
 
 window.osuny = window.osuny || {};
 
-var CLASSES = {
-    offcanvasOpened: 'has-offcanvas-opened',
-    linkActive: 'active',
-    isOpened: 'is-opened',
-    fullWidth: 'full-width',
-    offcanvas: 'offcanvas-toc'
-};
-
 window.osuny.TableOfContents = function (element) {
     this.element = element;
     this.content = this.element.querySelector('.toc-content');
@@ -18,21 +10,27 @@ window.osuny.TableOfContents = function (element) {
     this.links = this.element.querySelectorAll('a');
     this.sections = this.getSections();
     this.ctaTitle = document.querySelector('.toc-cta-title span');
-    this.openerButton = document.querySelector('.toc-cta button');
-    this.closingButton = document.querySelector('.toc-content > button');
+    this.buttonOpen = document.querySelector('.toc-cta button');
+    this.buttonClose = document.querySelector('.toc-content > button');
     this.togglers = document.querySelectorAll('.toc-cta button, .toc-container button');
+
     this.state = {
         opened: false,
         currentId: null,
         currentLink: 0,
-        isOffcanvas: null
+        isOffcanvas: this.isOffcanvas()
     };
+
+    this.classes = {
+        offcanvasOpened: 'has-offcanvas-opened',
+        linkActive: 'active',
+        isOpened: 'is-opened',
+        fullWidth: 'full-width',
+        offcanvas: 'offcanvas-toc'
+    };
+
     this.listen();
-    
-    this.state.isOffcanvas = this.isOffcanvas()
-    if (this.state.isOffcanvas) {
-        this.element.setAttribute('aria-hidden', true);
-    }
+    this.initializeAria();
 };
 
 window.osuny.TableOfContents.prototype.getSections = function () {
@@ -51,71 +49,72 @@ window.osuny.TableOfContents.prototype.getSections = function () {
     return sections;
 };
 
+window.osuny.TableOfContents.prototype.initializeAria = function () {
+    if (this.state.isOffcanvas) {
+        this.element.setAttribute('aria-hidden', true);
+    }
+}
+
 window.osuny.TableOfContents.prototype.isOffcanvas = function () {
-    return isMobile() || document.body.classList.contains(CLASSES.fullWidth) || document.body.classList.contains(CLASSES.offcanvas);
+    return isMobile() || document.body.classList.contains(this.classes.fullWidth) || document.body.classList.contains(this.classes.offcanvas);
 };
 
 window.osuny.TableOfContents.prototype.listen = function () {
     window.addEventListener('scroll', this.update.bind(this), false);
-
     window.addEventListener('resize', this.resize.bind(this), false);
 
-    this.togglers.forEach( function (toggler) {
-        toggler.addEventListener('click', function () {
-            this.toggle();
-        }.bind(this));
-    }.bind(this));
+    this.buttonOpen.addEventListener('click', this.open.bind(this));
+    this.buttonClose.addEventListener('click', this.close.bind(this));
 
-    this.links.forEach( function (links) {
-        links.addEventListener('click', function () {
-            this.toggle(false, true);
-        }.bind(this));
+    this.links.forEach( function (link) {
+        link.addEventListener('click', this.close.bind(this));
     }.bind(this));
 
     window.addEventListener('click', function (event) {
         if (event.target === document.body) {
-            this.toggle(false);
+            this.close();
         }
     }.bind(this));
 
     window.addEventListener('keydown', function (event) {
         if (event.keyCode === 27 || event.key === 'Escape') {
-            this.toggle(false);
+            this.close();
         }
         focusTrap(event, this.element, this.state.opened);
     }.bind(this));
 };
 
-window.osuny.TableOfContents.prototype.toggle = function (open, hasTarget) {
+window.osuny.TableOfContents.prototype.open = function () {
     if (!this.state.isOffcanvas) {
         return;
     }
-    this.state.opened = typeof open !== 'undefined' ? open : !this.state.opened;
-    var classAction = this.state.opened ? 'add' : 'remove',
-        transitionDuration = this.state.opened ? 0 : this.getTransitionDuration();
-
-    // TODO: refacto timeout and css transition
+    this.state.opened = true;
+    this.element.setAttribute('aria-hidden', false);
+    document.documentElement.classList.add(this.classes.offcanvasOpened);
     setTimeout( function () {
-        this.element.setAttribute('aria-hidden', !this.state.opened);
-    }.bind(this), transitionDuration * 1000);
-
-    setTimeout( function () {
-        this.element.classList[classAction](CLASSES.isOpened);
-        if (this.state.opened) {
-            this.closingButton.focus();
-        } else if (!hasTarget) {
-            this.openerButton.focus();
-        }
+        this.element.classList.add(this.classes.isOpened);
+        this.buttonClose.focus();
     }.bind(this), 50);
+};
 
-    document.documentElement.classList[classAction](CLASSES.offcanvasOpened);
-
+window.osuny.TableOfContents.prototype.close = function () {
+    if (!this.state.isOffcanvas) {
+        return;
+    }
+    this.state.opened = false;
+    this.element.classList.remove(this.classes.isOpened);
+    this.buttonOpen.focus();
+    document.documentElement.classList.remove(this.classes.offcanvasOpened);
+    setTimeout( function () {
+        this.element.setAttribute('aria-hidden', true);
+    }.bind(this), this.getTransitionDuration());
 };
 
 window.osuny.TableOfContents.prototype.getTransitionDuration = function () {
-    var transitionDuration = getComputedStyle(this.element).getPropertyValue('--toc-transition-duration');
-    transitionDuration = parseFloat(transitionDuration.replace('s', ''))
-    return transitionDuration;
+    var style = getComputedStyle(this.element),
+        property = style.getPropertyValue('transition-duration');
+        milliseconds = parseFloat(property.replace('s', '')) * 1000;
+    return milliseconds;
 };
 
 window.osuny.TableOfContents.prototype.update = function () {
@@ -147,26 +146,17 @@ window.osuny.TableOfContents.prototype.activateLink = function (id) {
 
     this.links.forEach( function (link) {
         if (link === currentLink) {
-            link.classList.add(CLASSES.linkActive);
+            link.classList.add(this.classes.linkActive);
             link.setAttribute('aria-current', 'true');
-            this.updateCtaTitle(link);
             this.state.id = id;
             this.state.currentLink = link;
         } else {
-            link.classList.remove(CLASSES.linkActive);
+            link.classList.remove(this.classes.linkActive);
             link.removeAttribute('aria-current');
         }
     }.bind(this));
 };
 
-window.osuny.TableOfContents.prototype.updateCtaTitle = function (link) {
-    if (isMobile()) {
-        this.openerButton.setAttribute('aria-label', link.innerText +  osuny.i18n.toc.button_label);
-        this.ctaTitle.innerText = link.innerText;
-    } else {
-        this.ctaTitle.innerText = this.ctaTitle.getAttribute('data-default');
-    }
-};
 
 window.osuny.TableOfContents.prototype.updateScrollspy = function (scroll) {
     var container = this.state.isOffcanvas ? this.nav : this.content;

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -4,15 +4,15 @@ import { focusTrap } from '../../utils/focus-trap';
 window.osuny = window.osuny || {};
 
 window.osuny.TableOfContents = function (element) {
-    this.element = element;
-    this.content = this.element.querySelector('.toc-content');
-    this.nav = this.element.querySelector('.toc');
-    this.links = this.element.querySelectorAll('a');
-    this.sections = this.getSections();
-    this.ctaTitle = document.querySelector('.toc-cta-title span');
-    this.buttonOpen = document.querySelector('.toc-cta button');
-    this.buttonClose = document.querySelector('.toc-content > button');
-    this.togglers = document.querySelectorAll('.toc-cta button, .toc-container button');
+    this.elements = {
+        root: element,
+        content: element.querySelector('.toc-content'),
+        nav: element.querySelector('.toc'),
+        links: element.querySelectorAll('a'),
+        sections: null,
+        buttonOpen: document.querySelector('.toc-cta button'),
+        buttonClose: document.querySelector('.toc-content > button')
+    }
 
     this.state = {
         opened: false,
@@ -29,30 +29,29 @@ window.osuny.TableOfContents = function (element) {
         offcanvas: 'offcanvas-toc'
     };
 
-    this.listen();
+    this.initializeSections();
     this.initializeAria();
+    this.listen();
 };
 
-window.osuny.TableOfContents.prototype.getSections = function () {
-    var sections = [],
-        id,
-        section;
-
-    this.links.forEach(function (link) {
+// Initialisation
+window.osuny.TableOfContents.prototype.initializeSections = function () {
+    var id,
+        section,
+        sections = this.elements.sections = [];
+    this.elements.links.forEach( function (link) {
         id = link.getAttribute('href').replace('#', '');
         section = document.getElementById(id);
         if (section) {
             sections.push(section);
         }
     });
-
-    return sections;
 };
 
 window.osuny.TableOfContents.prototype.initializeAria = function () {
     this.state.isOffcanvas = this.isOffcanvas()
     if (this.state.isOffcanvas) {
-        this.element.setAttribute('aria-hidden', true);
+        this.elements.root.setAttribute('aria-hidden', true);
     }
 }
 
@@ -66,39 +65,41 @@ window.osuny.TableOfContents.prototype.listen = function () {
     window.addEventListener('click', this.clickOnBackground.bind(this));
     window.addEventListener('keydown', this.pressEscape.bind(this));
 
-    this.buttonOpen.addEventListener('click', this.open.bind(this));
-    this.buttonClose.addEventListener('click', this.close.bind(this));
+    this.elements.buttonOpen.addEventListener('click', this.open.bind(this));
+    this.elements.buttonClose.addEventListener('click', this.close.bind(this));
 
-    this.links.forEach( function (link) {
+    this.elements.links.forEach( function (link) {
         link.addEventListener('click', this.close.bind(this));
     }.bind(this));
 };
+
+// Méthodes
 
 window.osuny.TableOfContents.prototype.open = function () {
     if (!this.state.isOffcanvas) {
         return;
     }
     this.state.opened = true;
-    this.element.setAttribute('aria-hidden', false);
+    this.elements.root.setAttribute('aria-hidden', false);
     document.documentElement.classList.add(this.classes.offcanvasOpened);
     setTimeout( function () {
-        this.element.classList.add(this.classes.isOpened);
-        this.buttonClose.focus();
+        this.elements.root.classList.add(this.classes.isOpened);
+        this.elements.buttonClose.focus();
     }.bind(this), 50);
 };
 
 window.osuny.TableOfContents.prototype.close = function () {
     this.state.opened = false;
-    this.element.classList.remove(this.classes.isOpened);
-    this.buttonOpen.focus();
+    this.elements.root.classList.remove(this.classes.isOpened);
+    this.elements.buttonOpen.focus();
     document.documentElement.classList.remove(this.classes.offcanvasOpened);
     setTimeout( function () {
-        this.element.setAttribute('aria-hidden', true);
+        this.elements.root.setAttribute('aria-hidden', true);
     }.bind(this), this.getTransitionDuration());
 };
 
 window.osuny.TableOfContents.prototype.getTransitionDuration = function () {
-    var style = getComputedStyle(this.element),
+    var style = getComputedStyle(this.elements.root),
         property = style.getPropertyValue('transition-duration');
         milliseconds = parseFloat(property.replace('s', '')) * 1000;
     return milliseconds;
@@ -107,7 +108,7 @@ window.osuny.TableOfContents.prototype.getTransitionDuration = function () {
 window.osuny.TableOfContents.prototype.update = function () {
     var scroll = document.documentElement.scrollTop || document.body.scrollTop;
     var id = null;
-    this.sections.forEach(function (section) {
+    this.elements.sections.forEach(function (section) {
         if (this.getAbsoluteOffsetTop(section) <= scroll + window.innerHeight / 2) {
             id = section.id;
         }
@@ -129,9 +130,9 @@ window.osuny.TableOfContents.prototype.getAbsoluteOffsetTop = function (element)
 };
 
 window.osuny.TableOfContents.prototype.activateLink = function (id) {
-    var currentLink = this.element.querySelector(`[href*='${id}']`);
+    var currentLink = this.elements.root.querySelector(`[href*='${id}']`);
 
-    this.links.forEach( function (link) {
+    this.elements.links.forEach( function (link) {
         if (link === currentLink) {
             link.classList.add(this.classes.linkActive);
             link.setAttribute('aria-current', 'true');
@@ -146,7 +147,7 @@ window.osuny.TableOfContents.prototype.activateLink = function (id) {
 
 
 window.osuny.TableOfContents.prototype.updateScrollspy = function (scroll) {
-    var container = this.state.isOffcanvas ? this.nav : this.content;
+    var container = this.state.isOffcanvas ? this.elements.nav : this.elements.content;
     if (this.state.currentLink && scroll > window.innerHeight) {
         var progress = this.getAbsoluteOffsetTop(this.state.currentLink) - container.offsetHeight / 2;
         progress = this.state.isOffcanvas ? progress : progress - scroll;
@@ -170,7 +171,7 @@ window.osuny.TableOfContents.prototype.pressEscape = function (event) {
     if (event.keyCode === 27 || event.key === 'Escape') {
         this.close();
     }
-    focusTrap(event, this.element, this.state.opened);
+    focusTrap(event, this.elements.root, this.state.opened);
 };
 
 window.osuny.page.registerComponent({

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -52,7 +52,7 @@ window.osuny.TableOfContents.prototype.initializeSections = function () {
 window.osuny.TableOfContents.prototype.initializeAria = function () {
     this.state.isOffcanvas = this.isOffcanvas()
     if (this.state.isOffcanvas) {
-        this.elements.root.setAttribute('aria-hidden', true);
+        this.elements.root.setAttribute('aria-hidden', 'true');
     }
 }
 
@@ -83,8 +83,12 @@ window.osuny.TableOfContents.prototype.listen = function () {
     window.addEventListener('keydown', this.pressEscape.bind(this));
     window.addEventListener('keydown', this.checkFocusTrap.bind(this));
 
-    this.elements.buttonOpen.addEventListener('click', this.open.bind(this));
-    this.elements.buttonClose.addEventListener('click', this.closeAndFocusButtonOpen.bind(this));
+    if (this.elements.buttonOpen) {
+        this.elements.buttonOpen.addEventListener('click', this.open.bind(this));
+    }
+    if (this.elements.buttonClose) {
+        this.elements.buttonClose.addEventListener('click', this.closeAndFocusButtonOpen.bind(this));
+    }
     this.elements.links.forEach( function (link) {
         link.addEventListener('click', this.close.bind(this));
     }.bind(this));
@@ -97,7 +101,7 @@ window.osuny.TableOfContents.prototype.open = function () {
         return;
     }
     this.state.opened = true;
-    this.elements.root.setAttribute('aria-hidden', false);
+    this.elements.root.setAttribute('aria-hidden', 'false');
     document.documentElement.classList.add(this.classes.offcanvasOpened);
     setTimeout( function () {
         this.elements.root.classList.add(this.classes.isOpened);
@@ -106,11 +110,14 @@ window.osuny.TableOfContents.prototype.open = function () {
 };
 
 window.osuny.TableOfContents.prototype.close = function () {
+    if (!this.state.isOffcanvas) {
+        return;
+    }
     this.state.opened = false;
     this.elements.root.classList.remove(this.classes.isOpened);
     document.documentElement.classList.remove(this.classes.offcanvasOpened);
     setTimeout( function () {
-        this.elements.root.setAttribute('aria-hidden', true);
+        this.elements.root.setAttribute('aria-hidden', 'true');
     }.bind(this), this.getTransitionDuration());
 };
 

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -9,7 +9,7 @@ window.osuny.TableOfContents = function (element) {
         content: element.querySelector('.toc-content'),
         nav: element.querySelector('.toc'),
         links: element.querySelectorAll('a'),
-        sections: null,
+        sections: [],
         buttonOpen: document.querySelector('.toc-cta button'),
         buttonClose: document.querySelector('.toc-content > button')
     }
@@ -39,7 +39,7 @@ window.osuny.TableOfContents = function (element) {
 window.osuny.TableOfContents.prototype.initializeSections = function () {
     var id,
         section,
-        sections = this.elements.sections = [];
+        sections = this.elements.sections;
     this.elements.links.forEach( function (link) {
         id = link.getAttribute('href').replace('#', '');
         section = document.getElementById(id);

--- a/assets/js/theme/design-system/components/toc.js
+++ b/assets/js/theme/design-system/components/toc.js
@@ -62,7 +62,7 @@ window.osuny.TableOfContents.prototype.isOffcanvas = function () {
 
 window.osuny.TableOfContents.prototype.getTransitionDuration = function () {
     var style = getComputedStyle(this.elements.root),
-        property = style.getPropertyValue('transition-duration');
+        property = style.getPropertyValue('transition-duration'),
         milliseconds = parseFloat(property.replace('s', '')) * 1000;
     return milliseconds;
 };
@@ -167,13 +167,13 @@ window.osuny.TableOfContents.prototype.resize = function () {
 };
 
 window.osuny.TableOfContents.prototype.clickOnBackground = function (event) {
-    if (event.target === document.body) {
+    if (this.state.opened && event.target === document.body) {
         this.closeAndFocusButtonOpen();
     }
 };
 
 window.osuny.TableOfContents.prototype.pressEscape = function (event) {
-    if (event.keyCode === 27 || event.key === 'Escape') {
+    if (this.state.opened && (event.keyCode === 27 || event.key === 'Escape')) {
         this.closeAndFocusButtonOpen();
     }
 };


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Petit brin de js pour terminer la partie accessibilité de la toc : 
- quand on ouvre la toc, le focus se met sur le bouton "fermer"
- quand on la ferme (esc ou clavier), le focus se place sur le bouton "table des matières"

Améliorations diverses 
- amélioration de la cohérence des noms de boutons (`buttonOpen` et `buttonClose`)
- suppression des `togglers` ambigus
- réintégration des classes flottantes dans le scope de l'objet
- création d'une fonction au nom explicite, `initializeAria`
- mise en cohérence des bindings des événéments
- suppression de la fonction `toggle`
- création des fonctions `open` et `close`
- rangement du calcul des millisecondes de la transition
- réparation de `--toc-transition-duration`, qui ne semble plus exister, remplacé par `transition-duration`
- suppression de la fonction `updateCtaTitle`, qui n'a plus de sens maintenant que la TOC mobile est cachée

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1015

## URL de test sur example.osuny.org

http://localhost:1313/fr/actualites/2024-11-18-la-nouvelle-visionneuse-dosuny/#avec-un-bloc-galerie-sans-visionneuse
http://localhost:1313/fr/actualites/2025-04-03-le-festin-de-pierres/