### PR TITLE
Ajustement de la liste des dates (cas avec uniquement des archives)

### DIFF
--- a/assets/sass/_theme/sections/events/single.sass
+++ b/assets/sass/_theme/sections/events/single.sass
@@ -219,12 +219,9 @@
                                 opacity: 1
         .event-summary + ul
             margin-top: $spacing-3
-        // Hide li childs:
-        // - after 6th one (included)
-        // - if its status is 'archive'
+        // Hide li childs after 6th one (included)
         ul.truncated-list
-            li:nth-child(n+7),
-            li.event-time-slot--archive
+            li:nth-child(n+7)
                 display: none
         ul:not(.truncated-list)
             + .btn


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Erreur de sélecteur sur les événements avec que des archives : 
<img width="1413" height="574" alt="Capture d’écran 2026-05-07 à 11 59 29" src="https://github.com/user-attachments/assets/e780514d-90c5-4151-8bf1-79ae663516e5" />

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/gaitelyrique-www/issues/153

## URL de test du site GL

`http://localhost:1313/agenda/2026/festivals-et-salles-de-concerts-en-europe-qui-possede-quoi/`

## Screenshots

<img width="1857" height="460" alt="Capture d’écran 2026-05-07 à 12 00 38" src="https://github.com/user-attachments/assets/a191fbd5-1b21-4617-be30-396282cbbe2a" />
<img width="1905" height="951" alt="Capture d’écran 2026-05-07 à 12 00 31" src="https://github.com/user-attachments/assets/c5d7eee3-0549-4f18-b9d9-c15829727abd" />