### PR TITLE
Bloc catégories : utilisation des informations du static

### DIFF
--- a/layouts/_partials/categories/partials/category.html
+++ b/layouts/_partials/categories/partials/category.html
@@ -1,6 +1,7 @@
 {{ $options := .options | default site.Params.categories.index.options }}
 {{ $heading_level := .heading_level }}
 {{ $category := site.GetPage .category.path }}
+{{ $count := .category.count }}
 {{ $layout := .layout }}
 
 {{ with $category }}
@@ -16,7 +17,7 @@
       {{ end }}
 
       {{ if $options.count }}
-        {{ partial "categories/partials/category/articles-count.html" . }}
+        {{ partial "categories/partials/category/articles-count.html" $count }}
       {{ end }}
 
       {{ if $options.more }}

--- a/layouts/_partials/categories/partials/category/articles-count.html
+++ b/layouts/_partials/categories/partials/category/articles-count.html
@@ -1,3 +1,1 @@
-{{ $section_type := strings.TrimSuffix "_categories" .Type }}
-{{ $label := i18n ( printf "%s.count" $section_type ) ( len .Pages ) }}
-<p class="articles-count">{{ $label }}</p>
+<p class="articles-count">{{ . }}</p>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [x] Rangement

## Description

Le calcul du thème n'était pas exact et il est plus sûr de se reposer sur le static : 

**Site :**

<img width="959" height="166" alt="Capture d’écran 2026-05-07 à 12 29 47" src="https://github.com/user-attachments/assets/e3116291-f58e-4896-a922-e2fa53cb4cf5" />

**Static :**

<img width="700" height="130" alt="Capture d’écran 2026-05-07 à 12 29 44" src="https://github.com/user-attachments/assets/00e21724-1db9-4c85-ba0a-138902783b8f" />

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org



## URL de test du site (optionnel)

https://commun.osuny.org/participer/

## Screenshots
<img width="1292" height="796" alt="Capture d’écran 2026-05-07 à 12 30 55" src="https://github.com/user-attachments/assets/3673c606-040a-48da-806a-4a8a48bafc95" />