### PR TITLE
Utilisation globale de la config `meta` (gestion de la position des taxonomies)

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -114,7 +114,7 @@ params:
         show_name: true
     single:
       meta:
-        position: content
+        position: hero
         options:
           authors: true
           dates: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -122,7 +122,7 @@ params:
           share: true
           updated_at: true
           year: true
-          with_labels: false
+          with_labels: true
     sitemap:
       ignore_children: false
   categories:

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -121,10 +121,8 @@ params:
           reading_time: true
           share: true
           updated_at: true
+          year: true
           with_labels: false
-      taxonomies:
-        position: content
-        show_name: false
     sitemap:
       ignore_children: false
   categories:

--- a/layouts/_partials/commons/categories.html
+++ b/layouts/_partials/commons/categories.html
@@ -8,6 +8,7 @@
   {{ $categories_type := printf "%ss_categories" $type }}
   {{ $categories = .context.GetTerms $categories_type }}
 {{ end }}
+
 {{ if $categories }}
   <ul class="{{ $class }}" aria-label="{{ i18n "categories.label" }}">
     {{ range $categories }}

--- a/layouts/_partials/header/hero/content/meta/list.html
+++ b/layouts/_partials/header/hero/content/meta/list.html
@@ -2,6 +2,7 @@
 
 {{ if and (ne .Kind "home") (ne .Type "events") (eq site.Params.default.single.meta.position "hero") }}
   <ul class="hero-infos {{ $label_class }}">
+    {{ partial "header/hero/content/meta/list/year.html" . }}
     {{ partial "header/hero/content/meta/list/dates.html" . }}
     {{ partial "header/hero/content/meta/list/author.html" . }}
     {{ partial "header/hero/content/meta/list/reading-time.html" . }}

--- a/layouts/_partials/header/hero/content/meta/list/reading-time.html
+++ b/layouts/_partials/header/hero/content/meta/list/reading-time.html
@@ -1,3 +1,3 @@
-{{ if and site.Params.default.single.meta.options.reading_time (in (slice "posts" "jobs") .Type) }}
+{{ if and site.Params.default.single.meta.options.reading_time (in (slice "posts" "jobs" "projects") .Type) }}
   {{ partial "commons/single/reading-time.html" . }}
 {{ end }}

--- a/layouts/_partials/header/hero/content/meta/list/share.html
+++ b/layouts/_partials/header/hero/content/meta/list/share.html
@@ -1,3 +1,3 @@
-{{ if and site.Params.default.single.meta.options.share (in (slice "posts" "jobs") .Type) }}
+{{ if and site.Params.default.single.meta.options.share (in (slice "posts" "jobs" "projects") .Type) }}
   {{ partial "commons/share/list-item.html" . }}
 {{ end }}

--- a/layouts/_partials/header/hero/content/meta/list/year.html
+++ b/layouts/_partials/header/hero/content/meta/list/year.html
@@ -1,0 +1,8 @@
+{{ if and site.Params.default.single.meta.options.year .Params.year }}
+  <li class="year">
+    {{ if site.Params.default.single.meta.options.with_labels }}
+      <span>{{ i18n "projects.year" }}</span>
+    {{ end }}
+    <time datetime="{{ . }}">{{ .Params.year }}</time>
+  </li>
+{{ end }}

--- a/layouts/_partials/header/hero/content/meta/taxonomies.html
+++ b/layouts/_partials/header/hero/content/meta/taxonomies.html
@@ -1,5 +1,3 @@
-{{ $taxonomies_position := partial "taxonomies/helpers/GetPosition" .context }}
-
-{{ if and .context.Params.taxonomies (eq $taxonomies_position "hero") }}
+{{ if and .context.Params.taxonomies }}
   {{ partial "taxonomies/single/list.html" .context }}
 {{ end }}

--- a/layouts/_partials/jobs/single/job-infos.html
+++ b/layouts/_partials/jobs/single/job-infos.html
@@ -1,12 +1,9 @@
 
 <ul class="job-infos">
-  {{ $taxonomies_position := partial "taxonomies/helpers/GetPosition" . }}
-  {{ if ne $taxonomies_position "hero" }}
-    {{ if .Params.jobs_categories }}
-      <li>
-        {{ partial "taxonomies/single/list.html" . }}
-      </li>
-    {{ end }}
+  {{ if .Params.jobs_categories }}
+    <li>
+      {{ partial "taxonomies/single/list.html" . }}
+    </li>
   {{ end }}
 
   {{ with .Params.dates }}

--- a/layouts/_partials/pages/single.html
+++ b/layouts/_partials/pages/single.html
@@ -11,7 +11,7 @@
     "block_wrapped" true
   ) }}
 
-  {{ if and .Params.taxonomies (eq site.Params.pages.single.taxonomies.position "content") }}
+  {{ if and .Params.taxonomies (eq site.Params.pages.single.meta.position "content") }}
     <div class="container taxonomies-container">
       {{ partial "taxonomies/single/list.html" . }}
     </div>

--- a/layouts/_partials/projects/single/hero.html
+++ b/layouts/_partials/projects/single/hero.html
@@ -4,7 +4,6 @@
   "title" $title
   "image" .Params.image
   "sizes" site.Params.image_sizes.sections.projects.hero_single
-  "hero_text_complement" ( partial "projects/single/hero/infos.html" . )
   "context" .
   "share" $share
 ) }}

--- a/layouts/_partials/projects/single/hero/infos.html
+++ b/layouts/_partials/projects/single/hero/infos.html
@@ -1,9 +1,0 @@
-{{ if .Params.design.full_width }}
-  {{ with .Params.year }}
-    <div class="project-infos">
-      <div class="year">
-        <time datetime="{{ . }}">{{ . }}</time>
-      </div>
-    </div>
-  {{ end }}
-{{ end }}

--- a/layouts/_partials/projects/single/project-infos.html
+++ b/layouts/_partials/projects/single/project-infos.html
@@ -1,7 +1,7 @@
 
 <ul class="project-infos">
   {{ $taxonomies_position := partial "taxonomies/helpers/GetPosition" . }}
-  {{ if ne $taxonomies_position "hero" }}
+  {{ if eq $taxonomies_position "content" }}
     {{ if .Params.projects_categories }}
       <li>
         {{ partial "taxonomies/single/list.html" . }}

--- a/layouts/_partials/projects/single/sidebar.html
+++ b/layouts/_partials/projects/single/sidebar.html
@@ -1,6 +1,6 @@
 <div class="section-sidebar project-sidebar">
   <div>
-    {{ if not .Params.design.full_width }}
+    {{ if and (eq site.Params.default.single.meta.position "content") (not .Params.design.full_width) }}
       <aside>
         {{- partial "projects/single/project-infos.html" . -}}
       </aside>

--- a/layouts/_partials/taxonomies/helpers/GetPosition.html
+++ b/layouts/_partials/taxonomies/helpers/GetPosition.html
@@ -2,11 +2,11 @@
 {{ if eq .Type "pages" }}
   {{ $kind = "single" }}
 {{ end }}
-{{ $param := (printf "%s.%s.taxonomies.position" .Type $kind )}}
+{{ $param := (printf "%s.%s.meta.position" .Type $kind )}}
 
 {{ $position := partial "helpers/param/GetSiteParamWithDefault" (dict 
   "param" $param
-  "default" (printf "default.%s.taxonomies.position" $kind)
+  "default" (printf "default.%s.meta.position" $kind)
 ) }}
 
 {{ return $position }}

--- a/layouts/_partials/taxonomies/single/list.html
+++ b/layouts/_partials/taxonomies/single/list.html
@@ -4,7 +4,7 @@
 {{ $param := printf "%s.single.taxonomies.show_name" $type }}
 {{ $display_taxonomies := partial "helpers/param/GetSiteParamWithDefault" (dict 
   "param" $param
-  "default" "default.single.taxonomies.show_name"
+  "default" "default.single.meta.options.with_label"
 ) }}
 {{ with $taxonomies }}
   {{ if $display_taxonomies }}

--- a/layouts/_partials/taxonomies/single/list.html
+++ b/layouts/_partials/taxonomies/single/list.html
@@ -1,10 +1,10 @@
 {{ $context := . }}
 {{ $type := .Type }}
 {{ $taxonomies := .Params.taxonomies }}
-{{ $param := printf "%s.single.taxonomies.show_name" $type }}
+{{ $param := printf "%s.single.meta.options.with_labels" $type }}
 {{ $display_taxonomies := partial "helpers/param/GetSiteParamWithDefault" (dict 
   "param" $param
-  "default" "default.single.meta.options.with_label"
+  "default" "default.single.meta.options.with_labels"
 ) }}
 {{ with $taxonomies }}
   {{ if $display_taxonomies }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

On abandonne l'usage de:
```
    single:
      taxonomies:
        position: content
        show_name: true
```
Pour gérer la position des taxonomies avec `meta`.
## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/actualites/2023-03-04-referentiel-general-decoconception-de-services-numeriques-rgesn/`
`http://localhost:1313/fr/projets/2025-ceci-est-un-projet/`
`http://localhost:1313/fr/offres-d-emploi/2025/offre-demploi-test-1/`