### PR TITLE
Déplacer l'`itemscope` des `singles`

### DIFF
--- a/layouts/_partials/jobs/single.html
+++ b/layouts/_partials/jobs/single.html
@@ -1,6 +1,6 @@
 {{ partial "jobs/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/JobPosting">
+<div class="document-content">
   <meta itemprop="title" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
   {{ with .Params.summary }}<meta itemprop="abstract" content="{{ . | safeHTML }}">{{ end }}

--- a/layouts/_partials/journals/single.html
+++ b/layouts/_partials/journals/single.html
@@ -1,6 +1,6 @@
 {{ partial "journals/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/Periodical">
+<div class="document-content">
   <meta itemprop="title" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
   {{ with .Params.summary }}<meta itemprop="abstract" content="{{ . | safeHTML }}">{{ end }}

--- a/layouts/_partials/laboratories/single.html
+++ b/layouts/_partials/laboratories/single.html
@@ -1,6 +1,6 @@
 {{ partial "laboratories/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/ResearchOrganization">
+<div class="document-content">
   <meta itemprop="title" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
   {{ with .Params.summary }}<meta itemprop="abstract" content="{{ . | safeHTML }}">{{ end }}

--- a/layouts/_partials/locations/single.html
+++ b/layouts/_partials/locations/single.html
@@ -1,6 +1,6 @@
 {{ partial "locations/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/EducationalOrganization">
+<div class="document-content">
   <meta itemprop="name" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
   {{ with .Params.summary }}<meta itemprop="description" content="{{ . | safeHTML }}">{{ end }}

--- a/layouts/_partials/organizations/single.html
+++ b/layouts/_partials/organizations/single.html
@@ -1,6 +1,6 @@
 {{ partial "organizations/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/Organization">
+<div class="document-content">
   {{ partial "toc/container.html" (dict
     "context" .
   ) }}

--- a/layouts/_partials/papers/single.html
+++ b/layouts/_partials/papers/single.html
@@ -1,6 +1,6 @@
 {{ partial "papers/section/hero.html" . }}
 
-<div class="document-content sidebar-on-{{ site.Params.papers.sidebar.direction }}" itemscope itemtype="https://schema.org/ScholarlyArticle">
+<div class="document-content sidebar-on-{{ site.Params.papers.sidebar.direction }}">
   <meta itemprop="name" content="{{ safeHTML .Title }}">
   {{ partial "papers/single/sidebar.html" . }}
 

--- a/layouts/_partials/posts/single.html
+++ b/layouts/_partials/posts/single.html
@@ -1,6 +1,6 @@
 {{ partial "posts/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/NewsArticle">
+<div class="document-content">
   <meta itemprop="headline" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
   {{ with .Date }}<meta itemprop="datePublished" content="{{ .Format "2006-01-02T15:04" }}">{{ end }}

--- a/layouts/_partials/programs/single.html
+++ b/layouts/_partials/programs/single.html
@@ -1,6 +1,6 @@
 {{ partial "programs/single/hero.html" . }}
 
-<div class="document-content {{ with .Params.diplomas }}diploma-{{.}}{{ end }}" itemscope itemtype="https://schema.org/EducationalOccupationalCredential">
+<div class="document-content {{ with .Params.diplomas }}diploma-{{.}}{{ end }}">
   <meta itemprop="name" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
 

--- a/layouts/_partials/projects/single.html
+++ b/layouts/_partials/projects/single.html
@@ -1,6 +1,6 @@
 {{ partial "projects/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/CreativeWork">
+<div class="document-content">
   <meta itemprop="name" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
   {{ with .Params.summary }}<meta itemprop="description" content="{{ . | safeHTML }}">{{ end }}

--- a/layouts/_partials/publications/single.html
+++ b/layouts/_partials/publications/single.html
@@ -1,6 +1,6 @@
 {{ partial "publications/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/ScholarlyArticle">
+<div class="document-content">
   <meta itemprop="name" content="{{ safeHTML .Title }}">
   
   <div class="container">

--- a/layouts/_partials/schools/single.html
+++ b/layouts/_partials/schools/single.html
@@ -1,6 +1,6 @@
 {{ partial "schools/single/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/CollegeOrUniversity">
+<div class="document-content">
   <meta itemprop="title" content="{{ safeHTML .Title }}">
   <meta itemprop="url" content="{{ .Permalink }}">
   {{ with .Params.summary }}<meta itemprop="abstract" content="{{ . | safeHTML }}">{{ end }}

--- a/layouts/_partials/volumes/single.html
+++ b/layouts/_partials/volumes/single.html
@@ -1,6 +1,6 @@
 {{ partial "volumes/section/hero.html" . }}
 
-<div class="document-content" itemscope itemtype="https://schema.org/PublicationVolume">
+<div class="document-content">
   <meta itemprop="name" content="{{ safeHTML .Title }}">
   {{- if .Params.image -}}
     {{- $image := partial "GetMedia" .Params.image.id -}}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -18,6 +18,7 @@
     <main id="main"
         {{ partial "main/helpers/GetClass" . | safeHTMLAttr }}
         {{ partial "main/helpers/GetSearchAttribute" . | safeHTMLAttr }}
+        {{ block "itemscope" . }}{{ end }}
         >
       {{ partial "commons/search/button.html" "fixed" }}
       {{ block "main" . }}{{ end }}

--- a/layouts/jobs/single.html
+++ b/layouts/jobs/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/JobPosting"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "jobs/single.html" . }}
 {{ end }}

--- a/layouts/journals/single.html
+++ b/layouts/journals/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/Periodical"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "journals/single.html" . }}
 {{ end }}

--- a/layouts/laboratories/single.html
+++ b/layouts/laboratories/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/ResearchOrganization"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "laboratories/single.html" . }}
 {{ end }}

--- a/layouts/locations/term.html
+++ b/layouts/locations/term.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/EducationalOrganization"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "locations/single.html" . }}
 {{ end }}

--- a/layouts/organizations/single.html
+++ b/layouts/organizations/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/Organization"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "organizations/single.html" . }}
 {{ end }}

--- a/layouts/papers/single.html
+++ b/layouts/papers/single.html
@@ -1,6 +1,7 @@
 {{ define "itemscope" }}
   itemscope itemtype="https://schema.org/ScholarlyArticle"
 {{ end }}
+
 {{ define "main" }}
   {{ partial "papers/single.html" . }}
 {{ end }}

--- a/layouts/papers/single.html
+++ b/layouts/papers/single.html
@@ -1,3 +1,6 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/ScholarlyArticle"
+{{ end }}
 {{ define "main" }}
   {{ partial "papers/single.html" . }}
 {{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/NewsArticle"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "posts/single.html" . }}
 {{ end }}

--- a/layouts/programs/section.html
+++ b/layouts/programs/section.html
@@ -1,3 +1,9 @@
+{{ define "itemscope" }}
+  {{ if ne .File.Path "programs/_index.html" }}
+    itemscope itemtype="https://schema.org/EducationalOccupationalCredential"
+  {{ end }}
+{{ end }}
+
 {{ define "main" }}
   {{ if eq .File.Path "programs/_index.html" }}
     {{ partial "programs/section.html" . }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/CreativeWork"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "projects/single.html" . }}
 {{ end }}

--- a/layouts/publications/single.html
+++ b/layouts/publications/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/ScholarlyArticle"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "publications/single.html" . }}
 {{ end }}

--- a/layouts/schools/single.html
+++ b/layouts/schools/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/CollegeOrUniversity"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "schools/single.html" . }}
 {{ end }}

--- a/layouts/volumes/term.html
+++ b/layouts/volumes/term.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/PublicationVolume"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "volumes/single.html" . }}
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

On déplace l'itemscope (schema.org) des objets sur la balise `main`. Cela permet d'inclure les meta, lorsqu'elles sont placées dans le hero.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
