### PR TITLE
Ajout de traductions pour la date de modification

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -239,6 +239,7 @@ commons:
     button_label: ", current - Table of contents"
   "yes": "Yes"
   updated_at: Updated at
+  update_at_inline: Updated on
   units:
     GB: GB
     MB: MB

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -209,6 +209,8 @@ commons:
     title: Índice
     button_label: ", atual - Índice"
   "true": Sim
+  updated_at: Data de atualização
+  update_at_inline: Atualizado a
   units:
     GB: GB
     MB: MB


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Ajout des clef de traductions allant avec l'ajout opéré dans #1512 

en : `update_at_inline: Updated on`
pt : `update_at_inline: Atualizado a`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱