### PR TITLE
Marge du `toc-cta` trop importante

### DIFF
--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -81,7 +81,6 @@
         @include container
         background: var(--color-background)
         justify-content: end
-        margin-bottom: var(--grid-gutter)
         position: sticky
         text-align: right
         top: calc(var(--header-height) * -1)

--- a/assets/sass/_theme/design-system/table_of_contents.sass
+++ b/assets/sass/_theme/design-system/table_of_contents.sass
@@ -81,6 +81,7 @@
         @include container
         background: var(--color-background)
         justify-content: end
+        margin-bottom: var(--grid-gutter)
         position: sticky
         text-align: right
         top: calc(var(--header-height) * -1)

--- a/assets/sass/_theme/sections/jobs.sass
+++ b/assets/sass/_theme/sections/jobs.sass
@@ -21,4 +21,4 @@
                 @include container
             
             @include media-breakpoint-up(desktop)
-                @include sidebar-full-width
+                @include aside-full-width

--- a/assets/sass/_theme/sections/posts.sass
+++ b/assets/sass/_theme/sections/posts.sass
@@ -272,7 +272,7 @@
                 @include container
             
             @include media-breakpoint-up(desktop)
-                @include sidebar-full-width
+                @include aside-full-width
 
 .related
     margin-top: $spacing-3

--- a/assets/sass/_theme/sections/projects.sass
+++ b/assets/sass/_theme/sections/projects.sass
@@ -185,7 +185,7 @@
                 @include container
             
             @include media-breakpoint-up(desktop)
-                @include sidebar-full-width
+                @include aside-full-width
     
     @include media-breakpoint-up(sm)
         .hero

--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -75,6 +75,7 @@
         align-items: start
         margin-bottom: $spacing-5
     .toc-cta
+        margin-bottom: 0
         padding-right: 0
     aside
         flex-shrink: 0

--- a/assets/sass/_theme/utils/sidebar.sass
+++ b/assets/sass/_theme/utils/sidebar.sass
@@ -68,11 +68,11 @@
                 border-top: var(--border-width) solid var(--color-border)
                 padding-top: $spacing-3
 
-@mixin sidebar-full-width
+@mixin aside-full-width
     @include container
     > div
+        align-items: baseline
         display: flex
-        align-items: start
         margin-bottom: $spacing-5
     .toc-cta
         margin-bottom: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Marge trop importante sous le cta (2x grid-gutter)

<img width="1440" height="650" alt="Capture d’écran 2026-05-26 à 11 20 00" src="https://github.com/user-attachments/assets/5c1d1f16-f698-4220-adc8-dfbfbb9eac8f" />

Nous n'avons pas trouvé l'utilité de cette marge.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/actualites/2025-04-03-le-festin-de-pierres/

## Screenshots
<img width="1444" height="530" alt="Capture d’écran 2026-05-26 à 11 20 16" src="https://github.com/user-attachments/assets/8a36f318-ccea-49d5-9ebe-c11a76a38f52" />
