### PR TITLE
Ajustement des metas : cas de la pleine largeur avec sidebar vide

### DIFF
--- a/assets/sass/_theme/design-system/meta.sass
+++ b/assets/sass/_theme/design-system/meta.sass
@@ -21,6 +21,9 @@
 
         .taxonomy-title
             text-align: left
+    
+    > li:first-child
+        padding-top: 0
 
 @mixin meta-with-labels-columns
     &, .taxonomies > ul

--- a/assets/sass/_theme/design-system/meta.sass
+++ b/assets/sass/_theme/design-system/meta.sass
@@ -21,9 +21,6 @@
 
         .taxonomy-title
             text-align: left
-    
-    > li:first-child
-        padding-top: 0
 
 @mixin meta-with-labels-columns
     &, .taxonomies > ul

--- a/assets/sass/_theme/design-system/meta.sass
+++ b/assets/sass/_theme/design-system/meta.sass
@@ -21,10 +21,6 @@
 
         .taxonomy-title
             text-align: left
-    
-    &
-        > li:first-child
-            padding-top: 0
 
 @mixin meta-with-labels-columns
     &, .taxonomies > ul

--- a/assets/sass/_theme/design-system/meta.sass
+++ b/assets/sass/_theme/design-system/meta.sass
@@ -21,6 +21,10 @@
 
         .taxonomy-title
             text-align: left
+    
+    &
+        > li:first-child
+            padding-top: 0
 
 @mixin meta-with-labels-columns
     &, .taxonomies > ul

--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -1,4 +1,5 @@
 .taxonomies-section
+    @include list-reset
     margin-top: var(--block-space-y)
     margin-bottom: var(--block-space-y)
     li

--- a/layouts/_partials/jobs/single/sidebar.html
+++ b/layouts/_partials/jobs/single/sidebar.html
@@ -1,7 +1,7 @@
 {{ $meta_position := partial "commons/single/meta/helpers/GetPosition" . }}
 {{ $meta_in_content := eq $meta_position "content" }}
 
-{{ if or (eq .Params.design.toc.present true) ($meta_in_content) }}
+{{ if or .Params.design.toc.present $meta_in_content }}
   <div class="section-sidebar job-sidebar">
     <div>
       {{ if eq $meta_position "content" }}

--- a/layouts/_partials/jobs/single/sidebar.html
+++ b/layouts/_partials/jobs/single/sidebar.html
@@ -1,14 +1,17 @@
 {{ $meta_position := partial "commons/single/meta/helpers/GetPosition" . }}
+{{ $meta_in_content := eq $meta_position "content" }}
 
-<div class="section-sidebar job-sidebar">
-  <div>
-    {{ if eq $meta_position "content" }}
-      <aside>
-        {{- partial "jobs/single/meta.html" . -}}
-      </aside>
-    {{ end }}
-    {{ partial "toc/container.html" (dict
+{{ if or (eq .Params.design.toc.present true) ($meta_in_content) }}
+  <div class="section-sidebar job-sidebar">
+    <div>
+      {{ if eq $meta_position "content" }}
+        <aside>
+          {{- partial "jobs/single/meta.html" . -}}
+        </aside>
+      {{ end }}
+      {{ partial "toc/container.html" (dict
       "context" .
-    ) }}
+      ) }}
+    </div>
   </div>
-</div>
+{{ end }}

--- a/layouts/_partials/jobs/single/sidebar.html
+++ b/layouts/_partials/jobs/single/sidebar.html
@@ -10,7 +10,7 @@
         </aside>
       {{ end }}
       {{ partial "toc/container.html" (dict
-      "context" .
+        "context" .
       ) }}
     </div>
   </div>

--- a/layouts/_partials/posts/single/sidebar.html
+++ b/layouts/_partials/posts/single/sidebar.html
@@ -11,7 +11,7 @@
       {{ end }}
       
       {{ partial "toc/container.html" (dict
-      "context" .
+        "context" .
       ) }}
     </div>
   </div>

--- a/layouts/_partials/posts/single/sidebar.html
+++ b/layouts/_partials/posts/single/sidebar.html
@@ -1,7 +1,7 @@
 {{ $meta_position := partial "commons/single/meta/helpers/GetPosition" . }}
 {{ $meta_in_content := eq $meta_position "content" }}
 
-{{ if or (eq .Params.design.toc.present true) ($meta_in_content) }}
+{{ if or .Params.design.toc.present $meta_in_content }}
   <div class="section-sidebar post-sidebar">
     <div>
       {{ if $meta_in_content }}

--- a/layouts/_partials/posts/single/sidebar.html
+++ b/layouts/_partials/posts/single/sidebar.html
@@ -1,15 +1,18 @@
 {{ $meta_position := partial "commons/single/meta/helpers/GetPosition" . }}
+{{ $meta_in_content := eq $meta_position "content" }}
 
-<div class="section-sidebar post-sidebar">
-  <div>
-    {{ if eq $meta_position "content" }}
-      <aside>
-        {{- partial "posts/single/meta.html" . -}}
-      </aside>
-    {{ end }}
-
-    {{ partial "toc/container.html" (dict
+{{ if or (eq .Params.design.toc.present true) ($meta_in_content) }}
+  <div class="section-sidebar post-sidebar">
+    <div>
+      {{ if $meta_in_content }}
+        <aside>
+          {{- partial "posts/single/meta.html" . -}}
+        </aside>
+      {{ end }}
+      
+      {{ partial "toc/container.html" (dict
       "context" .
-    ) }}
+      ) }}
+    </div>
   </div>
-</div>
+{{ end }}

--- a/layouts/_partials/projects/single/sidebar.html
+++ b/layouts/_partials/projects/single/sidebar.html
@@ -11,7 +11,7 @@
       {{ end }}
       
       {{ partial "toc/container.html" (dict
-      "context" .
+        "context" .
       ) }}
     </div>
   </div>

--- a/layouts/_partials/projects/single/sidebar.html
+++ b/layouts/_partials/projects/single/sidebar.html
@@ -1,15 +1,18 @@
 {{ $meta_position := partial "commons/single/meta/helpers/GetPosition" . }}
+{{ $meta_in_content := eq $meta_position "content" }}
 
-<div class="section-sidebar project-sidebar">
-  <div>
-    {{ if eq $meta_position "content" }}
-      <aside>
-        {{- partial "projects/single/meta.html" . -}}
-      </aside>
-    {{ end }}
-
-    {{ partial "toc/container.html" (dict
+{{ if or (eq .Params.design.toc.present true) ($meta_in_content) }}
+  <div class="section-sidebar project-sidebar">
+    <div>
+      {{ if $meta_in_content }}
+        <aside>
+          {{- partial "projects/single/meta.html" . -}}
+        </aside>
+      {{ end }}
+      
+      {{ partial "toc/container.html" (dict
       "context" .
-    ) }}
+      ) }}
+    </div>
   </div>
-</div>
+{{ end }}

--- a/layouts/_partials/projects/single/sidebar.html
+++ b/layouts/_partials/projects/single/sidebar.html
@@ -1,7 +1,7 @@
 {{ $meta_position := partial "commons/single/meta/helpers/GetPosition" . }}
 {{ $meta_in_content := eq $meta_position "content" }}
 
-{{ if or (eq .Params.design.toc.present true) ($meta_in_content) }}
+{{ if or .Params.design.toc.present $meta_in_content }}
   <div class="section-sidebar project-sidebar">
     <div>
       {{ if $meta_in_content }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Dans un cas sans meta ni toc, la div vide dans la sidebar a une marge vers le bas poussant le contenu
<img width="1917" height="336" alt="image" src="https://github.com/user-attachments/assets/e6f8bcee-e432-449f-8b23-68734d26955c" />

On vérifie maintenant la présence de la toc ou des meta avant d'afficher la sidebar pour : 
- les jobs
- les projects
- les posts

-> En mobile, les taxonomies des personnes ont une puce, car le display: `inline-block` du li n'est appliqué qu'en desktop : 
<img width="408" height="139" alt="Capture d’écran 2026-05-29 à 12 53 18" src="https://github.com/user-attachments/assets/36e9db4c-d589-42eb-ae2c-fd76245967f5" />
<img width="631" height="110" alt="Capture d’écran 2026-05-29 à 12 53 24" src="https://github.com/user-attachments/assets/3b6bd1d9-2504-4164-8012-e15f886e4625" />

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site Campus Transition
`http://localhost:1313/fr/publications/2026-comment-va-vivre-loperation-de-recherche-action-chalheureusement-votre/`

## Screenshots
<img width="1441" height="238" alt="Capture d’écran 2026-05-29 à 11 03 03" src="https://github.com/user-attachments/assets/b1388d4d-4493-4b26-8d32-dd1e0fe55c42" />
<img width="1437" height="254" alt="Capture d’écran 2026-05-29 à 11 03 10" src="https://github.com/user-attachments/assets/5f78d5f1-2013-478f-b856-bf71f0fb2dcd" />