### PR TITLE
Afficher un bouton de recherche sur les pages spéciales

### DIFF
--- a/assets/js/theme/design-system/components/search.js
+++ b/assets/js/theme/design-system/components/search.js
@@ -11,7 +11,7 @@ window.osuny.Search = function (element) {
         detailsContainer: element.querySelector('.pf-filter-pane'),
         buttonsOpen: document.querySelectorAll('.pf-trigger-btn'),
         buttonClose: document.querySelector('.pf-modal-close'),
-        buttonSearchInType: document.querySelector('.search-button--taxonomies'),
+        buttonSearchInType: document.querySelector('[data-search-in-type]'),
         pagefindInstance: window.PagefindComponents.getInstanceManager().getInstance('default'),
         pagefindFilters: document.querySelector('pagefind-filter-pane'),
         triggerButton: null
@@ -107,7 +107,7 @@ window.osuny.Search.prototype.close = function () {
 window.osuny.Search.prototype.setDetailsAttribute = function (open) {
     this.details = this.elements.detailsContainer.querySelectorAll('.pf-filter-group'); 
     this.attribute = open ? 'open' : '';
-    
+
     this.details.forEach( function (detail) {
         detail.open = open;
     }.bind(this));
@@ -119,8 +119,8 @@ window.osuny.Search.prototype.updateDocumentAccessibility = function () {
 };
 
 window.osuny.Search.prototype.searchInType = function () {
-    var container = document.querySelector('.section-taxonomies-container'),
-        type = container.getAttribute('data-filter-type');
+    var type = this.elements.buttonSearchInType.getAttribute('data-search-in-type');
+    console.log(type)
     this.elements.pagefindInstance.triggerFilter('type', [type]);
     this.elements.pagefindFilters.style.visibility = 'hidden';
 };

--- a/assets/sass/_theme/design-system/taxonomies.sass
+++ b/assets/sass/_theme/design-system/taxonomies.sass
@@ -20,6 +20,10 @@
         z-index: $zindex-toc + 1
         .taxonomies-list
             padding-left: offset(4)
+    .search-button
+        margin-right: auto
+        button
+            @include icon(search-line, after)
 
 .taxonomies-list
     > p

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -120,7 +120,7 @@ params:
         layout: dropdown # dropdown | inline
         show_name: true
       search:
-        active: true
+        active: false
     single:
       meta:
         position: content

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -119,6 +119,8 @@ params:
         display: true
         layout: dropdown # dropdown | inline
         show_name: true
+      search:
+        active: true
     single:
       meta:
         position: content

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -105,13 +105,6 @@ commons:
   authors:
     one: Author
     other: Authors
-  search:
-    close: Close search
-    filters: Filters
-    label: Search
-    placeholder: Search
-    search_label: Search this site
-    title: Search
   biography: Biography
   breadcrumb: Breadcrumb
   click_to_copy:
@@ -223,6 +216,16 @@ commons:
   published_at: Published at
   read: Read
   read_online: Read online
+  search:
+    close: Close search
+    filtered_by:
+      # placeholder: "Search in : {{ . }}"
+      placeholder: "Search"
+    filters: Filters
+    label: Search
+    placeholder: Search
+    search_label: Search this site
+    title: Search
   share: Share
   share_on: Share on
   share_on_aria: Share on “{{ .Title }}” - extern link

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -226,11 +226,15 @@ commons:
       hour: Heure de fin
   search:
     close: Fermer la recherche
+    filtered_by:
+      # placeholder: "Rechercher dans : {{ . }}"
+      placeholder: "Rechercher"
     filters: Filtres
     label: Recherche
     placeholder: Rechercher
     search_label: Recherche sur ce site
     title: Rechercher
+
   share: Partager
   share_on: Partager sur
   share_on_aria: Partager sur “{{ .Title }}” - lien externe

--- a/layouts/_partials/commons/search/button.html
+++ b/layouts/_partials/commons/search/button.html
@@ -5,8 +5,6 @@
       hide-shortcut="true"
       id="search-button-{{ $position }}"
       class="search-button search-button--{{ $position }}"
-      aria-expanded="false" 
-      aria-label='{{- i18n (printf "commons.search.title") -}}'
       >
   </pagefind-modal-trigger>
 {{ end }}

--- a/layouts/_partials/commons/search/button/filtered.html
+++ b/layouts/_partials/commons/search/button/filtered.html
@@ -5,8 +5,6 @@
     placeholder="{{ $placeholder }}"
     hide-shortcut="true"
     class="search-button search-button--{{ .position }}"
-    aria-expanded="false"
-    aria-label="{{ $placeholder }}"
     data-search-in-type="{{ $type_label }}"
     >
   </pagefind-modal-trigger>

--- a/layouts/_partials/commons/search/button/filtered.html
+++ b/layouts/_partials/commons/search/button/filtered.html
@@ -4,7 +4,8 @@
 ) }}
 {{ if and site.Params.search.active $search_in_index }}
   {{ $type_label := partial "commons/search/helpers/GetFilterLabelByType" .context }}
-  {{ $placeholder := i18n "commons.search.filtered_by.placeholder" $type_label }}
+  {{ $default_placeholder := i18n "commons.search.filtered_by.placeholder" $type_label }}
+  {{ $placeholder := i18n (printf "%s.index.search.label" .context.Type) | default $default_placeholder }}
   <pagefind-modal-trigger
     placeholder="{{ $placeholder }}"
     hide-shortcut="true"

--- a/layouts/_partials/commons/search/button/filtered.html
+++ b/layouts/_partials/commons/search/button/filtered.html
@@ -1,10 +1,14 @@
-{{ if and site.Params.search.active (in site.Params.search.positions .position) }}
+{{ $search_in_index := partial "helpers/param/GetSiteParamWithDefault" (dict 
+  "param" (printf "%s.index.search.active" .context.Type)
+  "default" "default.index.search.active"
+) }}
+{{ if and site.Params.search.active $search_in_index }}
   {{ $type_label := partial "commons/search/helpers/GetFilterLabelByType" .context }}
   {{ $placeholder := i18n "commons.search.filtered_by.placeholder" $type_label }}
   <pagefind-modal-trigger
     placeholder="{{ $placeholder }}"
     hide-shortcut="true"
-    class="search-button search-button--{{ .position }}"
+    class="search-button search-button--taxonomies"
     data-search-in-type="{{ $type_label }}"
     >
   </pagefind-modal-trigger>

--- a/layouts/_partials/commons/search/button/filtered.html
+++ b/layouts/_partials/commons/search/button/filtered.html
@@ -1,0 +1,13 @@
+{{ if and site.Params.search.active (in site.Params.search.positions .position) }}
+  {{ $type_label := partial "commons/search/helpers/GetFilterLabelByType" .context }}
+  {{ $placeholder := i18n "commons.search.filtered_by.placeholder" $type_label }}
+  <pagefind-modal-trigger
+    placeholder="{{ $placeholder }}"
+    hide-shortcut="true"
+    class="search-button search-button--{{ .position }}"
+    aria-expanded="false"
+    aria-label="{{ $placeholder }}"
+    data-search-in-type="{{ $type_label }}"
+    >
+  </pagefind-modal-trigger>
+{{ end }}

--- a/layouts/_partials/commons/search/modal.html
+++ b/layouts/_partials/commons/search/modal.html
@@ -1,5 +1,5 @@
 {{ if site.Params.search.active }}
-    <pagefind-modal reset-on-close="true">
+  <pagefind-modal reset-on-close="true">
     <div class="container">
       <pagefind-modal-header>
         <pagefind-input class="pf-input"></pagefind-input>
@@ -12,7 +12,12 @@
               <pagefind-filter-pane label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
             </div>
           </div>
-          <pagefind-results show-images hide-sub-results="true" class="pf-modal-results" max-results="20"></pagefind-results>
+          <pagefind-results
+            show-images
+            hide-sub-results="true"
+            class="pf-modal-results"
+            max-results="site.Params.search.max_results">
+          </pagefind-results>
         </div>
       </pagefind-modal-body>
       {{ partial "commons/search/hooks/before-modal-end.html" . }}

--- a/layouts/_partials/taxonomies/section/container.html
+++ b/layouts/_partials/taxonomies/section/container.html
@@ -1,5 +1,7 @@
 {{ if .Params.section_taxonomies }}
-  <div class="section-taxonomies-container">
+  {{ $type := partial "commons/search/helpers/GetFilterLabelByType" . }}
+  <div class="section-taxonomies-container" data-filter-type="{{ $type }}">
+    {{ partial "commons/search/button.html" "taxonomies" }}
     {{ partial "taxonomies/section/list.html" . }}
   </div>
 {{ end }}

--- a/layouts/_partials/taxonomies/section/container.html
+++ b/layouts/_partials/taxonomies/section/container.html
@@ -1,7 +1,5 @@
 {{ if .Params.section_taxonomies }}
-  {{ $type := partial "commons/search/helpers/GetFilterLabelByType" . }}
-  <div class="section-taxonomies-container" data-filter-type="{{ $type }}">
-    {{ partial "commons/search/button.html" "taxonomies" }}
+  <div class="section-taxonomies-container">
     {{ partial "taxonomies/section/list.html" . }}
   </div>
 {{ end }}

--- a/layouts/_partials/taxonomies/section/list.html
+++ b/layouts/_partials/taxonomies/section/list.html
@@ -7,6 +7,10 @@
 ) }}
 {{ if $options.display }}
   <div class="taxonomies-list taxonomies-list--{{ $options.layout }}">
+    {{ partial "commons/search/button/filtered.html" (dict
+      "position" "taxonomies"
+      "context" .
+    ) }}
     {{ range $taxonomies }}
       {{ if .categories }}
         {{ if eq $options.layout "dropdown" }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

### Afficher le bouton de recherche avec les filtres de taxonomies.

```
  search:
    active: true

  default:
    index: 
      search:
        active: false # disallow by default
  persons:
    index: 
      search:
        active: true # allow for persons
```

### Nombre de résultats maximum en config

```
search:
    max_results: 20
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots


<img width="1440" height="654" alt="image" src="https://github.com/user-attachments/assets/5fbcfb06-45d5-4d43-a9a7-967d66c85fdb" />

<img width="1440" height="772" alt="image" src="https://github.com/user-attachments/assets/2817cc6b-7496-450f-b0a7-617bb32b2237" />


