### PR TITLE
Recherche : scroll tronqué en mobile

### DIFF
--- a/assets/js/theme/design-system/components/search.js
+++ b/assets/js/theme/design-system/components/search.js
@@ -89,7 +89,6 @@ window.osuny.Search.prototype.updateDocumentAccessibility = function () {
 
 
 window.osuny.Search.prototype.openFilters = function () {
-    console.log('open filter')
     this.toggleFilters(true);
 };
 
@@ -99,7 +98,7 @@ window.osuny.Search.prototype.closeFilters = function () {
 
 window.osuny.Search.prototype.toggleFilters = function (opened = true) {
     this.details = this.elements.detailsContainer.querySelectorAll('.pf-filter-group');
-    console.log(this.details)
+
     this.details.forEach( function (detail) {
         detail.open = opened;
     }.bind(this));

--- a/assets/js/theme/design-system/components/search.js
+++ b/assets/js/theme/design-system/components/search.js
@@ -1,5 +1,4 @@
 import { ariaHideBodyChildren } from '../../utils/a11y';
-import { focusTrap } from '../../utils/focus-trap';
 import { isMobile } from '../../utils/breakpoints';
 
 window.osuny = window.osuny || {};
@@ -7,10 +6,8 @@ window.osuny = window.osuny || {};
 window.osuny.Search = function (element) {
     this.elements = {
         root: element,
-        sections: [],
         detailsContainer: element.querySelector('.pf-filter-pane'),
-        buttonsOpen: document.querySelectorAll('.pf-trigger-btn'),
-        buttonClose: document.querySelector('.pf-modal-close'),
+        triggerButtons: document.querySelectorAll('.pf-trigger-btn'),
         buttonSearchInType: document.querySelector('[data-search-in-type]'),
         pagefindFilters: document.querySelector('pagefind-filter-pane'),
         triggerButton: null
@@ -24,34 +21,23 @@ window.osuny.Search = function (element) {
     };
 
     this.listen();
+    this.resize();
 };
 
 window.osuny.Search.prototype.listen = function () {
     window.addEventListener('resize', this.resize.bind(this));
-    
-    this.elements.buttonsOpen.forEach(button => {
-        button.addEventListener('click', (event) => {
-            this.elements.triggerButton = event.currentTarget;
-            this.open();
-        });
-    });
-    
-    if (this.elements.buttonClose) {
-        this.elements.buttonClose.addEventListener('click', this.close.bind(this));
-    }
 
     if (this.elements.buttonSearchInType) {
         this.elements.buttonSearchInType.addEventListener('click', this.searchInType.bind(this));
     }
-    
-    window.addEventListener('keydown', function (event) {
-        if (this.state.isOpened) {
-            if (event.keyCode === 27 || event.key === 'Escape') {
-                this.close();
-            }
-        }
-        focusTrap(event, this.elements.root, this.state.isOpened);
-    }.bind(this), true);
+
+    this.elements.triggerButtons.forEach(function (button) {
+        button.addEventListener('click', function () {
+            this.elements.triggerButton = button;
+        }.bind(this));
+    }.bind(this));
+
+    this.elements.root.addEventListener('toggle', this.onToggle.bind(this));
 
     this.updateSearchFiltersToAny();
 };
@@ -70,75 +56,58 @@ window.osuny.Search.prototype.updateSearchFiltersToAny = function () {
 
 window.osuny.Search.prototype.resize = function () {
     this.state.isMobile = isMobile();
-    if (this.state.isOpened) {
-        if (isMobile()) {
-            this.close();
-        }
-    }
-};
-
-window.osuny.Search.prototype.getDetails = function () {
-    setTimeout(function() {
-        this.details = this.elements.detailsContainer.querySelectorAll('.pf-filter-group');
-
-        this.details.forEach( function (detail) {
-            detail.open = true;
-        }.bind(this));
-    }.bind(this), 200);
-};
-
-window.osuny.Search.prototype.open = function () {
-    if (this.elements.buttonSearchInType) {
-        this.resetType();
-    }
+    this.elements.pagefindFilters.expanded = !this.state.isMobile;
     if (this.state.isMobile) {
-        return;
+        this.closeFilters();
+    } else {
+        this.openFilters();
     }
 
-    this.state.isOpened = true;
-    this.updateDocumentAccessibility();
-
-    setTimeout(function() {
-        this.setDetailsAttribute(this.state.isOpened);
-    }.bind(this), 300);
 };
 
-window.osuny.Search.prototype.close = function () {
-    this.state.isOpened = false;
-    this.setDetailsAttribute(this.state.isOpened);
-    this.updateDocumentAccessibility();
-
-    // focus clicked search button
-    if (this.elements.triggerButton) {
-        setTimeout(function() {
-            this.elements.triggerButton.focus();
-        }.bind(this), 300);
+window.osuny.Search.prototype.onToggle = function (event) {
+    this.state.isOpened = event.newState === 'open';
+    if (!this.state.isOpened) {
+        this.onClose();
     }
-}
+    this.resize();
+    this.updateDocumentAccessibility();
+};
 
-window.osuny.Search.prototype.setDetailsAttribute = function (open) {
-    this.details = this.elements.detailsContainer.querySelectorAll('.pf-filter-group'); 
-    this.attribute = open ? 'open' : '';
 
-    this.details.forEach( function (detail) {
-        detail.open = open;
-    }.bind(this));
-}
+window.osuny.Search.prototype.onClose = function () {
+    if (this.elements.triggerButton) {
+        this.elements.triggerButton.focus();
+        this.elements.triggerButton = null;
+    }
+};
 
 window.osuny.Search.prototype.updateDocumentAccessibility = function () {
     document.body.style.overflow = this.state.isOpened ? 'hidden' : 'auto';
     ariaHideBodyChildren(this.elements.root, this.state.isOpened);
 };
 
+
+window.osuny.Search.prototype.openFilters = function () {
+    console.log('open filter')
+    this.toggleFilters(true);
+};
+
+window.osuny.Search.prototype.closeFilters = function () {
+    this.toggleFilters(false);
+};
+
+window.osuny.Search.prototype.toggleFilters = function (opened = true) {
+    this.details = this.elements.detailsContainer.querySelectorAll('.pf-filter-group');
+    console.log(this.details)
+    this.details.forEach( function (detail) {
+        detail.open = opened;
+    }.bind(this));
+};
+
 window.osuny.Search.prototype.searchInType = function () {
     var type = this.elements.buttonSearchInType.getAttribute('data-search-in-type');
     this.pagefindInstance.triggerFilter('type', [type]);
-    this.elements.pagefindFilters.style.visibility = 'hidden';
-};
-
-window.osuny.Search.prototype.resetType = function () {
-    this.pagefindInstance.triggerFilter('type', []);
-    this.elements.pagefindFilters.style.visibility = 'visible';
 };
 
 window.osuny.page.registerComponent({

--- a/assets/sass/_theme/vendors/pagefind.sass
+++ b/assets/sass/_theme/vendors/pagefind.sass
@@ -71,7 +71,7 @@
     @include meta
     background: var(--color-background)
     border: 0
-    height: 100svh
+    height: 100vh
     padding: 0
     margin: 0
     max-height: unset

--- a/assets/sass/_theme/vendors/pagefind.sass
+++ b/assets/sass/_theme/vendors/pagefind.sass
@@ -69,6 +69,7 @@
 
 .pf-modal
     @include meta
+    background: var(--color-background)
     border: 0
     height: 100svh
     padding: 0

--- a/assets/sass/_theme/vendors/pagefind.sass
+++ b/assets/sass/_theme/vendors/pagefind.sass
@@ -265,8 +265,14 @@
                     .pf-filter-group-name::after
                         transform: rotate(180deg)
 
-        .pf-result
-            &-image
-                display: none
-            &-excerpt
-                margin-top: $spacing-1
+        .pf-modal-content
+            display: flex
+            flex-direction: column
+        
+        .pf-modal-results
+            flex: 1
+            .pf-result
+                &-image
+                    display: none
+                &-excerpt
+                    margin-top: $spacing-1

--- a/assets/sass/_theme/vendors/pagefind.sass
+++ b/assets/sass/_theme/vendors/pagefind.sass
@@ -192,12 +192,11 @@
                     content: ''
                 .pf-filter-group-count
                     display: none
-                
+
             .pf-filter-fieldset
                 margin: 0
                 padding: 0
-                legend
-                    @include sr-only
+
 
     @include media-breakpoint-up(desktop)
         .pf-input-wrapper
@@ -234,9 +233,8 @@
             width: columns(3)
             .pf-summary
                 margin-bottom: $spacing-3
-            .pf-filter-pane
-                .pf-filter-group-title
-                    @include sr-only
+            .pf-filter-group-title
+                @include sr-only
 
     @include media-breakpoint-down(desktop)
         .pf-modal-header
@@ -252,6 +250,8 @@
             .pf-filter-pane
                 .pf-filter-fieldset
                     margin-bottom: $spacing-3
+                    legend
+                        display: none
                 .pf-filter-group-name
                     @include icon(arrow-down-s-line, after)
                     align-items: baseline

--- a/layouts/_partials/commons/search/modal.html
+++ b/layouts/_partials/commons/search/modal.html
@@ -9,7 +9,7 @@
           <div class="pf-modal-aside">
             <div class="pf-modal-aside-content">
               <pagefind-summary></pagefind-summary>
-              <pagefind-filter-pane label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
+              <pagefind-filter-pane expanded label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
             </div>
           </div>
           <pagefind-results


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

En mobile, le scroll n'affiche pas l'intégralité des résultats, le dernier est tronqué : 
<img width="396" height="677" alt="Capture d’écran 2026-06-03 à 14 56 19" src="https://github.com/user-attachments/assets/b828f69e-8ef2-40ea-88d7-3841e25a38d9" />

Avec du flex l'élément scrollable prend automatiquement la hauteur restante à l'intérieur de son parent.

## Screenshots
<img width="392" height="688" alt="Capture d’écran 2026-06-03 à 14 55 28" src="https://github.com/user-attachments/assets/41703ed5-064b-410a-8295-8fdad07e9d01" />
