### PR TITLE
Configuration de la taille des images : tailles additionnelles

### DIFF
--- a/layouts/_partials/commons/image/picture/bitmap.html
+++ b/layouts/_partials/commons/image/picture/bitmap.html
@@ -2,7 +2,7 @@
   {{ partial "commons/image/picture/bitmap/additionnal-size.html" . }}
   {{ partial "commons/image/picture/bitmap/size.html" (dict
     "crop" .crop
-    "media" "min-width: 1024px"
+    "media" "min-width: 1280px"
     "size" .sizes.desktop
     "url" .url
   ) }}

--- a/layouts/_partials/commons/image/picture/bitmap.html
+++ b/layouts/_partials/commons/image/picture/bitmap.html
@@ -1,4 +1,5 @@
 {{ if .sizes }}
+  {{ partial "commons/image/picture/bitmap/additionnal-size.html" . }}
   {{ partial "commons/image/picture/bitmap/size.html" (dict
     "crop" .crop
     "media" "min-width: 1024px"

--- a/layouts/_partials/commons/image/picture/bitmap/additionnal-size.html
+++ b/layouts/_partials/commons/image/picture/bitmap/additionnal-size.html
@@ -1,0 +1,10 @@
+{{ $url := .url }}
+{{ $crop := .crop }}
+{{ range .sizes.additionnal }}
+  {{ partial "commons/image/picture/bitmap/size.html" (dict
+    "crop" $crop
+    "media" .rule
+    "size" .size
+    "url" $url
+  ) }}
+{{ end }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

### Problèmatique

Par défaut, osuny permet de définir trois tailles d'image. Pour le desktop elle s'active au dessus de 1280px de large. 
Sur le site https://www.gaite-lyrique.net/, l'image d'en-tête de la page d'accueille occupe presque toute la largeur de l'écran.
Nous avons donc défini une taille pour cette image précisément à 1792px de large (sa largeur maximale). Sur un terminal avec un pixel ratio supérieur (x2), on charge une image de 3584px de large. Ça fait une image trop lourde pour des contextes d'écran de 1440px de large.

Pour gérer ce genre de cas particuliers, nous permettons d'ajouter des tailles additionnelles dans le configuration. Dans ce cas précis cela donne : 

```
image_sizes:
  sections:
      home:
        hero:
          mobile: 480
          tablet: 1200
          desktop: 1440
          additionnal:
            - rule: "min-width: 1560px"
              size: 1792
```


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Écran de 1440px de large avec un pixel ratio 2 : 

<img width="1439" height="414" alt="Capture d’écran 2026-06-04 à 11 16 57" src="https://github.com/user-attachments/assets/fa7cfd5f-8e06-46e5-abff-5ec8b5594465" />


Écran de 2048px de large avec un pixel ratio 2 : 

<img width="2048" height="611" alt="Capture d’écran 2026-06-04 à 11 17 06" src="https://github.com/user-attachments/assets/eca60293-c7bb-48f5-acd8-080c1f38060a" />



