### PR TITLE
Metas : ajustement mobile (table)

### DIFF
--- a/assets/sass/_theme/design-system/meta.sass
+++ b/assets/sass/_theme/design-system/meta.sass
@@ -118,6 +118,9 @@
         &.with-labels
             @include meta-with-labels-table
 
+            > li:first-child
+                padding-top: 0
+
     @include media-breakpoint-up(desktop)
         // in hero: 6 cols bc of picture
         &.hero-meta


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

En mobile et en format table avec labels, on a un espace trop important entre l'image et les meta à cause du padding du premier item :
<img width="375" height="502" alt="Capture d’écran 2026-06-04 à 12 07 24" src="https://github.com/user-attachments/assets/41d5f11d-ab4a-4481-a560-2715fa04740b" />

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`http://localhost:1313/fr/actualites/2025-04-03-le-festin-de-pierres/`

## Screenshots
<img width="374" height="500" alt="Capture d’écran 2026-06-04 à 12 07 07" src="https://github.com/user-attachments/assets/5b9c7195-f510-49ec-ac9b-026f2979b646" />