### PR TITLE
Meta : catégories en première position dans le format tableau

### DIFF
--- a/assets/sass/_theme/design-system/meta.sass
+++ b/assets/sass/_theme/design-system/meta.sass
@@ -45,7 +45,6 @@
                 &:first-of-type
                     @include sr-only
             &.taxonomies
-                width: 100%
                 order: 2
             &.social-share
                 order: 3

--- a/assets/sass/_theme/design-system/meta.sass
+++ b/assets/sass/_theme/design-system/meta.sass
@@ -18,7 +18,8 @@
             &.taxonomies
                 padding-top: 0
                 padding-bottom: 0
-
+        li.terms:first-child
+            padding-top: 0
         .taxonomy-title
             text-align: left
 
@@ -43,7 +44,11 @@
             > span
                 &:first-of-type
                     @include sr-only
-
+            &.taxonomies
+                width: 100%
+                order: 2
+            &.social-share
+                order: 3
         .authors
             ul
                 display: flex

--- a/bin/osuny.js
+++ b/bin/osuny.js
@@ -55,6 +55,7 @@ if (command === "watch") {
 }
 
 if (command === "dev") {
+    execute("rm -rf public");
     execute("hugo");
     execute("npx pagefind --site 'public' --output-subdir '../static/pagefind' --glob '**/index.{html}' --exclude-selectors '" + pagefindExclude + "'");
     execute("hugo server --minify");

--- a/layouts/_partials/commons/single/meta.html
+++ b/layouts/_partials/commons/single/meta.html
@@ -1,9 +1,9 @@
 {{ $meta_class := partial "commons/single/meta/helpers/GetMetaClass" . }}
 
 <ul class="{{ $meta_class }}">
+  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "commons/single/meta/dates.html" . }}
   {{ partial "commons/single/meta/authors.html" . }}
   {{ partial "commons/single/meta/reading-time.html" . }}
-  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "commons/single/meta/share.html" . }}
 </ul>

--- a/layouts/_partials/jobs/single/meta.html
+++ b/layouts/_partials/jobs/single/meta.html
@@ -1,9 +1,9 @@
 {{ $meta_class := partial "commons/single/meta/helpers/GetMetaClass" . }}
 
 <ul class="{{ $meta_class }}">
+  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "jobs/single/meta/dates.html" . }}
   {{ partial "commons/single/meta/authors.html" . }}
   {{ partial "commons/single/meta/reading-time.html" . }}
-  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "commons/single/meta/share.html" . }}
 </ul>

--- a/layouts/_partials/posts/single/meta.html
+++ b/layouts/_partials/posts/single/meta.html
@@ -1,9 +1,9 @@
 {{ $meta_class := partial "commons/single/meta/helpers/GetMetaClass" . }}
 
 <ul class="{{ $meta_class }}">
+  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "commons/single/meta/dates.html" . }}
   {{ partial "commons/single/meta/authors.html" . }}
   {{ partial "commons/single/meta/reading-time.html" . }}
-  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "commons/single/meta/share.html" . }}
 </ul>

--- a/layouts/_partials/projects/single/meta.html
+++ b/layouts/_partials/projects/single/meta.html
@@ -1,8 +1,8 @@
 {{ $meta_class := partial "commons/single/meta/helpers/GetMetaClass" . }}
 
 <ul class="{{ $meta_class }}">
+  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "projects/single/meta/year.html" . }}
   {{ partial "commons/single/meta/reading-time.html" . }}
-  {{ partial "commons/single/meta/taxonomies.html" . }}
   {{ partial "commons/single/meta/share.html" . }}
 </ul>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Mettre les catégories en premier quand les meta sont en mode tabeau.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

Avant : 

<img width="1953" height="517" alt="image" src="https://github.com/user-attachments/assets/00a77d8f-17c3-4e9d-a3f5-fc51308f6d1f" />

Après : 

<img width="1909" height="529" alt="image" src="https://github.com/user-attachments/assets/384354c5-9bbc-4e31-9815-3d94d0b13df8" />
