### PR TITLE
Debug tool : afficher le nombre de balises `html`

### DIFF
--- a/layouts/_partials/scripts/debug.html
+++ b/layouts/_partials/scripts/debug.html
@@ -7,3 +7,4 @@
 {{ partial "scripts/debug/open-in-production.html" }}
 {{ partial "scripts/debug/spacing.html" }}
 {{ partial "scripts/debug/full-width.html" }}
+{{ partial "scripts/debug/tags.html" }}

--- a/layouts/_partials/scripts/debug/help.html
+++ b/layouts/_partials/scripts/debug/help.html
@@ -35,6 +35,10 @@
           <td>Afficher les informations d'un bloc</td>
           <td>Ctrl + b</td>
         </tr>
+        <tr>
+          <td>Afficher le nombre de balises html</td>
+          <td>Ctrl + t</td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/layouts/_partials/scripts/debug/tags.html
+++ b/layouts/_partials/scripts/debug/tags.html
@@ -1,0 +1,27 @@
+<style>
+  .d-tags {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    background: var(--color-background);
+    padding: 20px;
+    z-index: 9999;
+  }
+</style>
+
+<div class="d-tags">
+  <p></p>
+</div>
+
+<script>
+  window.addEventListener('keydown', e => {
+    if (e.ctrlKey && e.key === 't') {
+      countHtmlTags();
+    }
+  });
+
+  function countHtmlTags() {
+    var count = document.querySelectorAll('*').length;
+    document.querySelector('.d-tags p').innerText = 'Nombre de balises html : ' + count;
+  }
+</script>


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Ajout du raccourci de debug pour afficher le nombre de balise `html`. Activable avec `ctrl + t`. Cela permet de facilement tester et mesurer les gains de réduction du DOM. 

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

<img width="1022" height="400" alt="image" src="https://github.com/user-attachments/assets/c2f5445c-6a94-4c0e-873f-b92a8d2e3824" />
