### PR TITLE
Hugo 0.161.1

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -4,7 +4,7 @@ services:
 module:
   hugoVersion:
     extended: true
-    min: 0.159.2
+    min: 0.161.1
 removePathAccents: true
 ignoreLogs: ['warning-goldmark-raw-html']
 markup:


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement
- [x] Montée de version

## Description

Monter de version en hugo 0.161.1.

Le thème supporte actuellement cette version. Il n'y a pas de modifications à effectuer.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
