### PR TITLE
9.4.2

### DIFF
--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -171,7 +171,6 @@ small, .small
 %multiple-lists
     ul, ol
         // https://since1979.dev/aligning-your-lists-with-your-text/
-        // list-style: 
         list-style-position: outside
         padding-left: var(--body-size)
         > li
@@ -181,12 +180,24 @@ small, .small
             padding-left: $spacing-2
             @include media-breakpoint-up(desktop)
                 padding-left: $spacing-3
-    
     ul
         list-style-type: disc
-
+        ul
+            list-style-type: circle
     ol
-        list-style-type: decimal
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Counter_styles/Using_counters
+        counter-reset: section
+        list-style-type: none
+        list-style-position: inside
+        > li::before
+            counter-increment: section
+            content: counters(section, ".") " "
+    > ol
+        padding-left: 0
+        > li::before
+            content: counters(section, "") ". "
+
+
 
 .rich-text
     word-break: break-word

--- a/assets/sass/_theme/sections/organizations.sass
+++ b/assets/sass/_theme/sections/organizations.sass
@@ -140,9 +140,6 @@
                 margin-top: 0
             &:not(:first-child)
                 margin-top: $spacing-5
-    &:not(.full-width)
-        .organization-presentation-container
-            padding-left: offset(4)
     @include media-breakpoint-down(md)
         .document-content
             .organization-logo
@@ -150,6 +147,9 @@
                 display: flex
                 justify-content: space-between
     @include media-breakpoint-up(md)
+        &:not(.full-width)
+            .organization-presentation-container
+                padding-left: offset(4)
         .document-content
             > .container
                 display: flex

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -270,9 +270,9 @@ errors:
   error_404:
     title: "404 error"
     text: >-
-      This link seems incorrect.<br>
+      <p>This link seems incorrect.<br>
       We suggest you return to the <a href="/">home page of our site</a>.<br>
-      Thank you for your understanding.
+      Thank you for your understanding.</p>
 events:
   archives:
     by_year: Archives by year

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -285,9 +285,9 @@ errors:
   error_404:
     title: Erreur 404
     text: >-
-      Ce lien semble erroné.<br>
+      <p>Ce lien semble erroné.<br>
       Nous vous proposons de retourner à la <a href="/">page d'accueil de notre site</a>.<br>
-      Merci de votre compréhension.
+      Merci de votre compréhension.</p>
 events:
   archives:
     by_year: Agenda par année

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -237,9 +237,9 @@ errors:
   error_404:
     title: Erro 404
     text: >-
-      Este link parece estar incorreto.<br>
+      <p>Este link parece estar incorreto.<br>
       Sugerimos que você retorne para a <a href="/">página inicial do nosso site</a>.<br>
-      Agradecemos sua compreensão.
+      Agradecemos sua compreensão.</p>
 events:
   archives: Acessar os arquivos de eventos passados
   add_to_calendar:

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -5,8 +5,8 @@
     "context" .
   ) }}
   <div class="container">
-    <p>
+    <div class="rich-text">
       {{ safeHTML (i18n "errors.error_404.text") }}
-    </p>
+    </div>
   </div>
 {{ end }}


### PR DESCRIPTION
[Correction mineure du menu : classe de lien nil](https://github.com/osunyorg/theme/pull/1534)

[Retirer les list-reset](https://github.com/osunyorg/theme/pull/1516)

[Chargement JSON des organisations dans les cartes des catégories](https://github.com/osunyorg/theme/pull/1536)

[Hugo 0.162](https://github.com/osunyorg/theme/pull/1541)

[Organisations et personnes : meta dans le hero et gestion de la largeur partielle
](https://github.com/osunyorg/theme/pull/1549)

[Variables d'espacement verticaux dans les rich-text](https://github.com/osunyorg/theme/pull/1553)


## Évolutions visuelles

### Listes et espacements verticaux dans les `rich-text`

L'espacement entre un paragraphe `p` et les listes `ol`, `ul` ont été réduits. L'espacement entre les paragraphes a également évolué. Ces espacements sont variables en fonction de la taille du texte courant : `1.25em` entre les éléments à l'intérieur des textes riches, et `0.3em` entre un `p` et une liste `ol`, `ul`.

#### Avant / Après 

Avant : 
<img width="1002" height="749" alt="Capture d’écran 2026-06-16 à 12 26 03" src="https://github.com/user-attachments/assets/ec998dba-c5d9-4f91-9ee8-2cb354f12d2a" />

Après : 

<img width="959" height="729" alt="Capture d’écran 2026-06-16 à 12 26 09" src="https://github.com/user-attachments/assets/1442a28e-7594-4580-b38f-96d7c2ab50ed" />


### Style des listes

<img width="394" height="486" alt="image" src="https://github.com/user-attachments/assets/0dd96435-8a8a-4ffc-8272-1b506f3cd31c" />



