### PR TITLE
Formations: ajustement de la couleur des essentials

### DIFF
--- a/assets/sass/_theme/design-system/hero.sass
+++ b/assets/sass/_theme/design-system/hero.sass
@@ -117,7 +117,7 @@
                 justify-content: space-between
         .essential
             @include meta
-            color: $header-color
+            color: $hero-color
             flex-wrap: wrap
             font-size: $program-essential-font-size
             margin-bottom: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

La partie des meta essentials du hero des programme prend la couleur du header, au lieu de celle du hero
<img width="712" height="132" alt="Capture d’écran 2026-06-09 à 12 24 16" src="https://github.com/user-attachments/assets/cef8bac3-3a07-4056-ad2a-57b8599e3c76" />

<img width="703" height="123" alt="Capture d’écran 2026-06-09 à 12 19 23" src="https://github.com/user-attachments/assets/ed9a12a6-e13a-40d3-b7ea-c20f23aefd5d" />

À vérifier sur les sites de formation.

## Niveau d'incidence

- [ ] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱