### PR TITLE
Formations : masquer la balise du short name quand il n'y en a pas

### DIFF
--- a/layouts/_partials/programs/partials/program/core/diploma.html
+++ b/layouts/_partials/programs/partials/program/core/diploma.html
@@ -1,6 +1,8 @@
 {{ with .Params.diplomas }}
   {{- $diploma := site.GetPage (printf "/diplomas/%s" .) -}}
   {{- with $diploma -}}
-    <span class="program-diploma">{{ safeHTML .Params.short_name }}</span>
+    {{- with .Params.short_name -}}
+      <span class="program-diploma">{{ safeHTML . }}</span>
+    {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Dans le cas d'un diplôme sans clef `short_name`, on affichait quand même la balise span devant le contenir.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site ENSSAT

http://localhost:1313/formations/