### PR TITLE
Page formations : ne pas générer la liste des formations si un bloc formation est présent

### DIFF
--- a/layouts/_partials/organizations/section/helpers/HasBlockOrganizations.html
+++ b/layouts/_partials/organizations/section/helpers/HasBlockOrganizations.html
@@ -1,8 +1,8 @@
 {{ $is_organizations_block_present := false }}
 
 {{ range .Params.contents }}
-  {{- if eq .template "organizations" -}}
-    {{- $is_organizations_block_present = true -}}
+  {{ if eq .template "organizations" }}
+    {{ $is_organizations_block_present = true }}
   {{ end }}
 {{ end }}
 

--- a/layouts/_partials/persons/section/helpers/HasBlockPersons.html
+++ b/layouts/_partials/persons/section/helpers/HasBlockPersons.html
@@ -1,8 +1,8 @@
-{{- $is_block_persons_present := false -}}
+{{ $is_block_persons_present := false }}
 
 {{ range .Params.contents }}
-  {{- if eq .template "persons" -}}
-    {{- $is_block_persons_present = true -}}
+  {{ if eq .template "persons" }}
+    {{ $is_block_persons_present = true }}
   {{ end }}
 {{ end }}
 

--- a/layouts/_partials/programs/section.html
+++ b/layouts/_partials/programs/section.html
@@ -16,5 +16,7 @@
 
   {{ partial "taxonomies/section/container.html" . }}
 
-  {{ partial "programs/section/programs.html" . }}
+  {{ if not ( partial "programs/section/helpers/HasBlockPrograms" . ) }}
+    {{ partial "programs/section/programs.html" . }}
+  {{ end }}
 </div>

--- a/layouts/_partials/programs/section/helpers/HasBlockPrograms.html
+++ b/layouts/_partials/programs/section/helpers/HasBlockPrograms.html
@@ -1,8 +1,8 @@
-{{- $is_block_programs_present := false -}}
+{{ $is_block_programs_present := false }}
 
 {{ range .Params.contents }}
-  {{- if eq .template "programs" -}}
-    {{- $is_block_programs_present = true -}}
+  {{ if eq .template "programs" }}
+    {{ $is_block_programs_present = true }}
   {{ end }}
 {{ end }}
 

--- a/layouts/_partials/programs/section/helpers/HasBlockPrograms.html
+++ b/layouts/_partials/programs/section/helpers/HasBlockPrograms.html
@@ -1,0 +1,9 @@
+{{- $is_block_programs_present := false -}}
+
+{{ range .Params.contents }}
+  {{- if eq .template "programs" -}}
+    {{- $is_block_programs_present = true -}}
+  {{ end }}
+{{ end }}
+
+{{ return $is_block_programs_present }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Si un bloc formation est présent sur la page spéciale des formations, on ne génère pas la liste de formations par défaut.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

<img width="1202" height="1029" alt="image" src="https://github.com/user-attachments/assets/1a261a04-47ba-481b-aa9a-0892ad9d0340" />

