### PR TITLE
Affichage des backlinks dans les tables des matières

### DIFF
--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -250,6 +250,12 @@ commons:
   toc: 
     title: Table des matières
     button_label: ", en cours - Table des matières"
+    backlinks:
+      events: Événements
+      exhibitions: Expositions
+      pages: Pages
+      posts: Actualités
+      projects: Projets
   "true": Oui
   updated_at: Date de modification
   update_at_inline: modifié le
@@ -411,6 +417,7 @@ persons:
     posts: Actualités publiées récemment
     programs: Enseignements
     publications: Publications
+
 posts:
   author: Auteur·rice
   authors:

--- a/layouts/_partials/contents/backlinks/events.html
+++ b/layouts/_partials/contents/backlinks/events.html
@@ -1,28 +1,30 @@
 {{ if .events }}
-  {{ $title := i18n "backlinks.events" .about }}
-  {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
-    "param" "persons.single.events"
-    "default" "events.index"
-  ) }}
-  {{ partial "blocks/templates/agenda.html" (dict
-    "block" (dict
-      "top" (dict
-        "active" true
-        "title" (dict
-          "value" $title
-          "heading" 2
+  <div id="{{ anchorize (i18n "commons.toc.backlinks.events") }}">
+    {{ $title := i18n "backlinks.events" .about }}
+    {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
+      "param" "persons.single.events"
+      "default" "events.index"
+    ) }}
+    {{ partial "blocks/templates/agenda.html" (dict
+      "block" (dict
+        "top" (dict
+          "active" true
+          "title" (dict
+            "value" $title
+            "heading" 2
+          )
+        )
+        "template" "agenda"
+        "ranks" (dict
+          "base" 2
+          "self" 2
+        )
+        "data" (dict
+          "events" .events
+          "layout" $params.layout
+          "options" $params.options
         )
       )
-      "template" "agenda"
-      "ranks" (dict
-        "base" 2
-        "self" 2
-      )
-      "data" (dict
-        "events" .events
-        "layout" $params.layout
-        "options" $params.options
-      )
-    )
-  ) }}
+    ) }}
+  </div>
 {{ end }}

--- a/layouts/_partials/contents/backlinks/exhibitions.html
+++ b/layouts/_partials/contents/backlinks/exhibitions.html
@@ -1,28 +1,30 @@
 {{ if .exhibitions }}
-  {{ $title := i18n "backlinks.exhibitions" .about }}
-  {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
-    "param" "persons.single.exhibitions"
-    "default" "exhibitions.index"
-  ) }}
-  {{ partial "blocks/templates/exhibitions.html" (dict
-    "block" (dict
-      "top" (dict
-        "active" true
-        "title" (dict
-          "value" $title
-          "heading" 2
+  <div id="{{ anchorize (i18n "commons.toc.backlinks.exhibitions") }}">
+    {{ $title := i18n "backlinks.exhibitions" .about }}
+    {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
+      "param" "persons.single.exhibitions"
+      "default" "exhibitions.index"
+    ) }}
+    {{ partial "blocks/templates/exhibitions.html" (dict
+      "block" (dict
+        "top" (dict
+          "active" true
+          "title" (dict
+            "value" $title
+            "heading" 2
+          )
+        )
+        "template" "agenda"
+        "ranks" (dict
+          "base" 2
+          "self" 2
+        )
+        "data" (dict
+          "exhibitions" .exhibitions
+          "layout" $params.layout
+          "options" $params.options
         )
       )
-      "template" "agenda"
-      "ranks" (dict
-        "base" 2
-        "self" 2
-      )
-      "data" (dict
-        "exhibitions" .exhibitions
-        "layout" $params.layout
-        "options" $params.options
-      )
-    )
-  ) }}
+    ) }}
+  </div>
 {{ end }}

--- a/layouts/_partials/contents/backlinks/pages.html
+++ b/layouts/_partials/contents/backlinks/pages.html
@@ -1,28 +1,30 @@
 {{ if .pages }}
-  {{ $title := i18n "backlinks.pages" .about }}
-  {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
-    "param" "persons.single.pages"
-    "default" "pages.index"
-  ) }}
-  {{ partial "blocks/templates/pages.html" (dict
-    "block" (dict
-      "top" (dict
-        "active" true
-        "title" (dict
-          "value" $title
-          "heading" 2
+  <div id="{{ anchorize (i18n "commons.toc.backlinks.pages") }}">
+    {{ $title := i18n "backlinks.pages" .about }}
+    {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
+      "param" "persons.single.pages"
+      "default" "pages.index"
+    ) }}
+    {{ partial "blocks/templates/pages.html" (dict
+      "block" (dict
+        "top" (dict
+          "active" true
+          "title" (dict
+            "value" $title
+            "heading" 2
+          )
+        )
+        "template" "pages"
+        "ranks" (dict
+          "base" 2
+          "self" 2
+        )
+        "data" (dict
+          "pages" .pages
+          "layout" $params.layout
+          "options" $params.options
         )
       )
-      "template" "pages"
-      "ranks" (dict
-        "base" 2
-        "self" 2
-      )
-      "data" (dict
-        "pages" .pages
-        "layout" $params.layout
-        "options" $params.options
-      )
-    )
-  ) }}
+    ) }}
+  </div>
 {{ end }}

--- a/layouts/_partials/contents/backlinks/posts.html
+++ b/layouts/_partials/contents/backlinks/posts.html
@@ -1,28 +1,30 @@
 {{ if .posts }}
-  {{ $title := i18n "backlinks.posts" .about }}
-  {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
-    "param" "persons.single.posts"
-    "default" "posts.index"
-  ) }}
-  {{ partial "blocks/templates/posts.html" (dict
-    "block" (dict
-      "top" (dict
-        "active" true
-        "title" (dict
-          "value" $title
-          "heading" 2
+  <div id="{{ anchorize (i18n "commons.toc.backlinks.posts") }}">
+    {{ $title := i18n "backlinks.posts" .about }}
+    {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
+      "param" "persons.single.posts"
+      "default" "posts.index"
+    ) }}
+    {{ partial "blocks/templates/posts.html" (dict
+      "block" (dict
+        "top" (dict
+          "active" true
+          "title" (dict
+            "value" $title
+            "heading" 2
+          )
+        )
+        "template" "posts"
+        "ranks" (dict
+          "base" 2
+          "self" 2
+        )
+        "data" (dict
+          "posts" .posts
+          "layout" $params.layout
+          "options" $params.options
         )
       )
-      "template" "posts"
-      "ranks" (dict
-        "base" 2
-        "self" 2
-      )
-      "data" (dict
-        "posts" .posts
-        "layout" $params.layout
-        "options" $params.options
-      )
-    )
-  ) }}
+    ) }}
+  </div>
 {{ end }}

--- a/layouts/_partials/contents/backlinks/projects.html
+++ b/layouts/_partials/contents/backlinks/projects.html
@@ -1,28 +1,30 @@
 {{ if .projects }}
-  {{ $title := i18n "backlinks.projects" .about }}
-  {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
-    "param" "persons.single.projects"
-    "default" "projects.index"
-  ) }}
-  {{ partial "blocks/templates/projects.html" (dict
-    "block" (dict
-      "top" (dict
-        "active" true
-        "title" (dict
-          "value" $title
-          "heading" 2
+  <div id="{{ anchorize (i18n "commons.toc.backlinks.projects") }}">
+    {{ $title := i18n "backlinks.projects" .about }}
+    {{ $params := partial "helpers/param/GetLayoutAndOptions" (dict 
+      "param" "persons.single.projects"
+      "default" "projects.index"
+    ) }}
+    {{ partial "blocks/templates/projects.html" (dict
+      "block" (dict
+        "top" (dict
+          "active" true
+          "title" (dict
+            "value" $title
+            "heading" 2
+          )
+        )
+        "template" "projects"
+        "ranks" (dict
+          "base" 2
+          "self" 2
+        )
+        "data" (dict
+          "projects" .projects
+          "layout" $params.layout
+          "options" $params.options
         )
       )
-      "template" "projects"
-      "ranks" (dict
-        "base" 2
-        "self" 2
-      )
-      "data" (dict
-        "projects" .projects
-        "layout" $params.layout
-        "options" $params.options
-      )
-    )
-  ) }}
+    ) }}
+  </div>
 {{ end }}

--- a/layouts/_partials/persons/single.html
+++ b/layouts/_partials/persons/single.html
@@ -6,7 +6,8 @@
     "context" .
     "toc" ( partial "persons/single/toc.html" . )
   ) }}
-  <div itemscope itemtype="https://schema.org/Person" class="container">
+
+  <div class="container">
     {{ partial "persons/single/meta.html" . }}
     {{ partial "persons/single/informations.html" . }}
     {{ partial "taxonomies/single/container.html" . }}

--- a/layouts/_partials/persons/single/toc.html
+++ b/layouts/_partials/persons/single/toc.html
@@ -5,5 +5,8 @@
     {{ partial "persons/single/toc/publications.html" . }}
     {{ partial "persons/single/toc/posts.html" . }}
     {{ partial "persons/single/toc/papers.html" . }}
+    {{ if site.Params.persons.single.backlinks }}
+      {{ partial "persons/single/toc/backlinks.html" . }}
+    {{ end }}
   </ol>
 </nav>

--- a/layouts/_partials/persons/single/toc/backlinks.html
+++ b/layouts/_partials/persons/single/toc/backlinks.html
@@ -1,0 +1,27 @@
+{{ with .Params.backlinks.current_website }}
+  {{ if .exhibitions }}
+    <li>
+      <a {{ partial "helpers/anchor/GetAttribute" (i18n "commons.toc.backlinks.exhibitions") }}>{{ i18n "commons.toc.backlinks.exhibitions" }}</a>
+    </li>
+  {{ end }}
+  {{ if .events }}
+    <li>
+      <a {{ partial "helpers/anchor/GetAttribute" (i18n "commons.toc.backlinks.events") }}>{{ i18n "commons.toc.backlinks.events" }}</a>
+    </li>
+  {{ end }}
+  {{ if .pages }}
+    <li>
+      <a {{ partial "helpers/anchor/GetAttribute" (i18n "commons.toc.backlinks.pages") }}>{{ i18n "commons.toc.backlinks.pages" }}</a>
+    </li>
+  {{ end }}
+  {{ if .projects }}
+    <li>
+      <a {{ partial "helpers/anchor/GetAttribute" (i18n "commons.toc.backlinks.projects") }}>{{ i18n "commons.toc.backlinks.projects" }}</a>
+    </li>
+  {{ end }}
+  {{ if .posts }}
+    <li>
+      <a {{ partial "helpers/anchor/GetAttribute" (i18n "commons.toc.backlinks.posts") }}>{{ i18n "commons.toc.backlinks.posts" }}</a>
+    </li>
+  {{ end }}
+{{ end }}

--- a/layouts/persons/single.html
+++ b/layouts/persons/single.html
@@ -1,3 +1,7 @@
+{{ define "itemscope" }}
+  itemscope itemtype="https://schema.org/Person"
+{{ end }}
+
 {{ define "main" }}
   {{ partial "persons/single.html" . }}
 {{ end }}


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Affichage des backlinks pour les personnes et organisations dans les tables des matières.

Il manque la gestion des backlinks des organisations.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Screenshots

<img width="382" height="610" alt="image" src="https://github.com/user-attachments/assets/2a11077a-bf7c-465b-a8fc-850bf7e40830" />


