### PR TITLE
Variables d'espacement verticaux dans les `rich-text`

### DIFF
--- a/assets/sass/_theme/configuration/typography.sass
+++ b/assets/sass/_theme/configuration/typography.sass
@@ -154,3 +154,7 @@ $link-unhover-decoration-color-alpha: 0.3 !default
 // Quote
 $inline-quotation-tag-open: '“' !default
 $inline-quotation-tag-close: '”' !default
+
+// Rich text
+$rich-text-vertical-space-before: 1.25em !default
+$rich-text-vertical-space-before-list: 0.3em !default

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -192,11 +192,9 @@ small, .small
     word-break: break-word
     @extend %multiple-lists
     > * + *
-        // margin-top: space(4)
-        margin-top: 1.25em
+        margin-top: $rich-text-vertical-space-before
     > * + ul, > * + ol
-        // margin-top: space(2)
-        margin-top: 0.3em
+        margin-top: $rich-text-vertical-space-before-list
     meta + *
         margin-top: 0
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -321,7 +321,6 @@ params:
           reading_time: false
           share: false
           updated_at: false
-          with_labels: false
   papers:
     default_image: false
     sidebar:


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Il est possible de configuration l'espacement vertical entre les éléments d'un texte riche (`rich-text`).

```
// Rich text
$rich-text-vertical-space-before: 1.25em !default
$rich-text-vertical-space-before-list: 0.3em !default
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
