### PR TITLE
Les textes des 404 incluent le balisage `html` et style des listes imbriquées

### DIFF
--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -181,9 +181,10 @@ small, .small
             padding-left: $spacing-2
             @include media-breakpoint-up(desktop)
                 padding-left: $spacing-3
-    
     ul
         list-style-type: disc
+        ul
+            list-style-type: circle
 
     ol
         list-style-type: decimal

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -171,7 +171,6 @@ small, .small
 %multiple-lists
     ul, ol
         // https://since1979.dev/aligning-your-lists-with-your-text/
-        // list-style: 
         list-style-position: outside
         padding-left: var(--body-size)
         > li
@@ -185,19 +184,19 @@ small, .small
         list-style-type: disc
         ul
             list-style-type: circle
-
-    // ol
-    //     list-style-type: decimal
     ol
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Counter_styles/Using_counters
         counter-reset: section
         list-style-type: none
-        li::before
+        list-style-position: inside
+        > li::before
             counter-increment: section
             content: counters(section, ".") " "
     > ol
-        list-style-type: decimal
+        padding-left: 0
         > li::before
-            content: ""
+            content: counters(section, "") ". "
+
 
 
 .rich-text

--- a/assets/sass/_theme/design-system/typography.sass
+++ b/assets/sass/_theme/design-system/typography.sass
@@ -186,8 +186,19 @@ small, .small
         ul
             list-style-type: circle
 
+    // ol
+    //     list-style-type: decimal
     ol
+        counter-reset: section
+        list-style-type: none
+        li::before
+            counter-increment: section
+            content: counters(section, ".") " "
+    > ol
         list-style-type: decimal
+        > li::before
+            content: ""
+
 
 .rich-text
     word-break: break-word

--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -270,9 +270,9 @@ errors:
   error_404:
     title: "404 error"
     text: >-
-      This link seems incorrect.<br>
+      <p>This link seems incorrect.<br>
       We suggest you return to the <a href="/">home page of our site</a>.<br>
-      Thank you for your understanding.
+      Thank you for your understanding.</p>
 events:
   archives:
     by_year: Archives by year

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -285,9 +285,9 @@ errors:
   error_404:
     title: Erreur 404
     text: >-
-      Ce lien semble erroné.<br>
+      <p>Ce lien semble erroné.<br>
       Nous vous proposons de retourner à la <a href="/">page d'accueil de notre site</a>.<br>
-      Merci de votre compréhension.
+      Merci de votre compréhension.</p>
 events:
   archives:
     by_year: Agenda par année

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -237,9 +237,9 @@ errors:
   error_404:
     title: Erro 404
     text: >-
-      Este link parece estar incorreto.<br>
+      <p>Este link parece estar incorreto.<br>
       Sugerimos que você retorne para a <a href="/">página inicial do nosso site</a>.<br>
-      Agradecemos sua compreensão.
+      Agradecemos sua compreensão.</p>
 events:
   archives: Acessar os arquivos de eventos passados
   add_to_calendar:

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -5,8 +5,8 @@
     "context" .
   ) }}
   <div class="container">
-    <p>
+    <div class="rich-text">
       {{ safeHTML (i18n "errors.error_404.text") }}
-    </p>
+    </div>
   </div>
 {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [x] Ajustement
- [ ] Rangement

## Description

Style de listes imbriquées :

<img width="485" height="489" alt="image" src="https://github.com/user-attachments/assets/c80ecaf2-310f-4d1c-aaa1-c550b51bf6ff" />


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

