### PR TITLE
Taxonomies position : nettoyage du fichier de configuration

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -137,7 +137,6 @@ params:
           updated_at: true
           with_labels: true
       taxonomies: # for organizations, persons, events and exhibitions (to be removed with meta)
-        position: content # content | hero | none
         show_name: true
     sitemap:
       ignore_children: false
@@ -375,8 +374,6 @@ params:
           status: false
           subtitle: true
           summary: true
-      taxonomies:
-        position: content # content | hero | none
   posts:
     default_image: false
     date_format: ":date_long"


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [x] Rangement

## Description

Les taxonomies sont affichés dans les `meta` d'un objet. La position des taxonomies dans une single devient alors obsolète.

Nettoyage des sites : https://github.com/search?q=org%3Aosunyorg+taxonomies+position+language%3Ayaml+NOT+repo%3Aosunyorg%2Ftheme&type=code&p=1

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
