### PR TITLE
Recherche : correction des filtres sur safari

### DIFF
--- a/assets/js/theme/design-system/components/search.js
+++ b/assets/js/theme/design-system/components/search.js
@@ -56,13 +56,6 @@ window.osuny.Search.prototype.updateSearchFiltersToAny = function () {
 
 window.osuny.Search.prototype.resize = function () {
     this.state.isMobile = isMobile();
-    this.elements.pagefindFilters.expanded = !this.state.isMobile;
-    if (this.state.isMobile) {
-        this.closeFilters();
-    } else {
-        this.openFilters();
-    }
-
 };
 
 window.osuny.Search.prototype.onToggle = function (event) {
@@ -85,23 +78,6 @@ window.osuny.Search.prototype.onClose = function () {
 window.osuny.Search.prototype.updateDocumentAccessibility = function () {
     document.body.style.overflow = this.state.isOpened ? 'hidden' : 'auto';
     ariaHideBodyChildren(this.elements.root, this.state.isOpened);
-};
-
-
-window.osuny.Search.prototype.openFilters = function () {
-    this.toggleFilters(true);
-};
-
-window.osuny.Search.prototype.closeFilters = function () {
-    this.toggleFilters(false);
-};
-
-window.osuny.Search.prototype.toggleFilters = function (opened = true) {
-    this.details = this.elements.detailsContainer.querySelectorAll('.pf-filter-group');
-
-    this.details.forEach( function (detail) {
-        detail.open = opened;
-    }.bind(this));
 };
 
 window.osuny.Search.prototype.searchInType = function () {

--- a/assets/sass/_theme/design-system/layout.sass
+++ b/assets/sass/_theme/design-system/layout.sass
@@ -86,6 +86,7 @@ details
         padding-top: $spacing-2
         position: relative
         cursor: pointer
+        list-style: none
         @include icon(arrow-down-s-line, after)
             line-height: pxToRem(22)
             transition: transform $default-duration

--- a/assets/sass/_theme/vendors/pagefind.sass
+++ b/assets/sass/_theme/vendors/pagefind.sass
@@ -178,11 +178,19 @@
             font-weight: normal
 
     .pf-modal-aside
+        
         .pf-summary
             margin-bottom: $spacing-2
             &:empty
                 display: none
-
+        .pf-filter-pane-container
+            display: none
+            &--desktop
+                @include media-breakpoint-up(desktop)
+                    display: block
+            &--mobile
+                @include media-breakpoint-down(desktop)
+                    display: block
         .pf-filter-pane
             .pf-filter-group
                 border: 0

--- a/layouts/_partials/commons/search/modal.html
+++ b/layouts/_partials/commons/search/modal.html
@@ -9,7 +9,8 @@
           <div class="pf-modal-aside">
             <div class="pf-modal-aside-content">
               <pagefind-summary></pagefind-summary>
-              <pagefind-filter-pane expanded auto-open-threshold="0" label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
+              <pagefind-filter-pane class="pf-filter-pane-container pf-filter-pane-container--desktop" expanded auto-open-threshold="0" label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
+              <pagefind-filter-pane class="pf-filter-pane-container pf-filter-pane-container--mobile" auto-open-threshold="0" label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
             </div>
           </div>
           <pagefind-results


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Correction de l'affichage des filtres sur Safari. Plutôt que de changer l'état du dropdown des filtres, on duplique le composant : un ouvert pour le desktop, et un fermé pour le mobile.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
