### PR TITLE
Personne : ajustement du style des rôles

### DIFF
--- a/assets/sass/_theme/sections/persons/single.sass
+++ b/assets/sass/_theme/sections/persons/single.sass
@@ -40,6 +40,7 @@
     .roles
         @include meta
         span
+            color: var(--color-text-alt)
             display: block
     .blocks
         margin-top: $spacing-5

--- a/assets/sass/_theme/sections/persons/single.sass
+++ b/assets/sass/_theme/sections/persons/single.sass
@@ -38,8 +38,9 @@
                         margin-bottom: 0
                         width: columns(3)
     .roles
-        a
-            @include small
+        @include meta
+        span
+            display: block
     .blocks
         margin-top: $spacing-5
     .person-objects

--- a/layouts/_partials/persons/single/informations/program-roles.html
+++ b/layouts/_partials/persons/single/informations/program-roles.html
@@ -6,7 +6,7 @@
       {{ $role := .title }}
       {{ if in .persons $slug }}
         <p>
-          {{ safeHTML $role }}<br>
+          <span>{{ safeHTML $role }}</span>
           <a href="{{ $program.Permalink }}" class="link">{{ safeHTML $program.Title }}</a>
         </p>
       {{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Suite aux changements de style des metas, le style des rôles des personnes ne colle plus : 

<img width="1439" height="675" alt="Capture d’écran 2026-06-23 à 17 10 30" src="https://github.com/user-attachments/assets/333b86f9-7f2a-491a-b00b-ca8934ee043c" />

On ajuste aussi le html pour enlever le `<br>`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site GCCD

`http://localhost:1313/personnes/nadine-paguet/`

## Screenshots

<img width="1440" height="651" alt="image" src="https://github.com/user-attachments/assets/bb6458a5-de3f-4011-aa90-759b066c1cc0" />

Avec une bio : 
<img width="1439" height="642" alt="image" src="https://github.com/user-attachments/assets/7ab06085-1671-4aaa-a800-f89b77d8be10" />