### PR TITLE
Fix RSS title

### DIFF
--- a/layouts/_partials/rss/item.html
+++ b/layouts/_partials/rss/item.html
@@ -1,8 +1,6 @@
 <item>
   <title>
-    {{- printf "<![CDATA[" | safeHTML }}
-      {{ .item.Title }}
-    {{ printf "]]>" | safeHTML -}}
+    {{ printf "<title><![CDATA[%s]]></title>" .item.Title | safeHTML }}
   </title>
   <link>{{ .item.Permalink }}</link>
   <pubDate>{{ .item.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>

--- a/layouts/_partials/rss/item.html
+++ b/layouts/_partials/rss/item.html
@@ -1,7 +1,5 @@
 <item>
-  <title>
-    {{ printf "<title><![CDATA[%s]]></title>" .item.Title | safeHTML }}
-  </title>
+  {{ printf "<title><![CDATA[%s]]></title>" .item.Title | safeHTML }}
   <link>{{ .item.Permalink }}</link>
   <pubDate>{{ .item.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
   {{- with .authorEmail }}<author>{{ . }}{{ with .authorName }} ({{ . }}){{ end }}</author>{{ end }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Suite à la PR #1539, tous les titles des flux RSS ont cassé. Cela est dû à un problème d'échappement du CDATA dont le comportement diffèrent que l'on soit dans une balise `<title>` ou `<description>`.

Une solution est de tout interpoler via un `printf`.

Sources:
- https://discourse.gohugo.io/t/first-is-getting-escaped-in-rss-content/30634/6
- https://github.com/gohugoio/hugo/issues/1740

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

Problème remonté par Antoine Raoul de chez Rennes le 24/06/2026 à 10h13

<img width="861" height="501" alt="image" src="https://github.com/user-attachments/assets/50f1a34f-a406-4994-80d3-cd78fa33613d" />

## URL de test sur example.osuny.org

`https://example.osuny.org/fr/index.xml`

## Screenshots

### ICI Rennes avec problème

Vue XML

<img width="1213" height="413" alt="image" src="https://github.com/user-attachments/assets/e685a800-e767-47e4-a439-523fbf39ff64" />

Vue code source

<img width="1029" height="301" alt="image" src="https://github.com/user-attachments/assets/f2e02acf-a47b-4893-b2a2-ae3519342838" />

### Example avec fix

Vue XML

<img width="850" height="406" alt="image" src="https://github.com/user-attachments/assets/bfac0632-212d-4b6e-a0e4-83641547a078" />

Vue code source

<img width="1154" height="335" alt="image" src="https://github.com/user-attachments/assets/3eae58a9-1b1b-4d1c-99e3-622cf55f4878" />
