### PR TITLE
Metas : ajout de la vérification de la présence de l'option `year`

### DIFF
--- a/layouts/_partials/commons/single/meta/helpers/HasContent.html
+++ b/layouts/_partials/commons/single/meta/helpers/HasContent.html
@@ -5,6 +5,7 @@
 {{ $has_share := partial "commons/single/meta/helpers/has/Share" . }}
 {{ $has_taxonomies := partial "commons/single/meta/helpers/has/Taxonomies" . }}
 {{ $has_updated_at := partial "commons/single/meta/helpers/has/UpdatedAt" . }}
+{{ $has_year := partial "commons/single/meta/helpers/has/Year" . }}
 
 {{ return (or
   $has_authors
@@ -14,4 +15,5 @@
   $has_share
   $has_taxonomies
   $has_updated_at
+  $has_year
 ) }}

--- a/layouts/_partials/commons/single/meta/helpers/has/Year.html
+++ b/layouts/_partials/commons/single/meta/helpers/has/Year.html
@@ -1,0 +1,4 @@
+{{ return partial "helpers/param/GetSiteParamWithDefault" (dict
+  "param" (printf "%s.single.meta.options.year" .Type)
+  "default" "default.single.meta.options.year"
+) }}

--- a/layouts/_partials/commons/single/meta/year.html
+++ b/layouts/_partials/commons/single/meta/year.html
@@ -1,6 +1,6 @@
-{{ $with_year := site.Params.projects.single.meta.options.year }}
+{{ $has_year := partial "commons/single/meta/helpers/has/Year" . }}
 
-{{ if and $with_year .Params.year }}
+{{ if and $has_year .Params.year }}
   <li class="year">
     <span>{{ i18n "projects.year" }}</span>
     <time datetime="{{ .Params.year }}">{{ .Params.year }}</time>

--- a/layouts/_partials/projects/single/meta.html
+++ b/layouts/_partials/projects/single/meta.html
@@ -2,7 +2,7 @@
 
 <ul class="{{ $meta_class }}">
   {{ partial "commons/single/meta/taxonomies.html" . }}
-  {{ partial "projects/single/meta/year.html" . }}
+  {{ partial "commons/single/meta/year.html" . }}
   {{ partial "commons/single/meta/reading-time.html" . }}
   {{ partial "commons/single/meta/share.html" . }}
 </ul>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Sur osuny.org, dans un projet, l'année de ce dernier disparaît avec la 9.5.
La cause est le manque de vérification du param `year` dans `HasContent.html`.

Ça fonctionnait sur example ou encore campus car HasContent était `true` du fait de la présence des taxos.

Faut-il aussi rapatrier `year.html` dans les commons ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site Osuny-www

`http://localhost:1313/references/2026-cmjnrvb-studio/`