### PR TITLE
Papiers : ajout d'une liste et suppression d'un doublon de schema

### DIFF
--- a/layouts/_partials/papers/single/authors.html
+++ b/layouts/_partials/papers/single/authors.html
@@ -1,22 +1,12 @@
 {{ if .Params.Researchers }}
   <section class="paper-authors" id="authors">
     <h2>{{ i18n "volumes.authors" }}</h2>
-    <div class="authors">
+    <ul class="authors">
       {{ range .Params.Researchers }}
-
         {{ with site.GetPage (printf "/persons/%s" .) }}
-          <div itemprop="author" itemscope itemtype="https://schema.org/Person">
-            <meta itemprop="name" content="{{ trim .Title "\n" }}">
-            <meta itemprop="url" content="{{ .Permalink }}">
-            <meta itemprop="description" content="{{ trim .Params.summary "\n" }}">
-            {{ if .Params.image }}
-              <meta itemprop="image" content="{{ .Params.image }}">
-            {{ end }}
-            {{ partial "persons/partials/person.html" (dict "person" .) }}
-          </div>
+          {{ partial "persons/partials/person.html" (dict "person" .) }}
         {{ end }}
-
       {{ end }}
-    </div>
+    </ul>
   </section>
 {{ end }}

--- a/layouts/_partials/persons/partials/person.html
+++ b/layouts/_partials/persons/partials/person.html
@@ -3,18 +3,18 @@
 <li>
   <article class="{{ $class }}" itemscope itemtype="https://schema.org/Person">
     <meta itemprop="url" content="{{ .person.Permalink }}">
-    <meta itemprop="image" content="{{ .person.Params.image }}">
-      {{ partial "persons/partials/person/description.html" (dict
-        "person" .person
-        "options" $options
-        "role" .role
-        "heading_level" .heading_level
-        "layout" .layout
-      ) }}
+    {{ partial "persons/partials/person/description.html" (dict
+      "person" .person
+      "options" $options
+      "role" .role
+      "heading_level" .heading_level
+      "layout" .layout
+    ) }}
     {{ if $options.image }}
       {{ partial "persons/partials/person/avatar.html" (dict
         "person" .person
         "sizes" .image_sizes
+        "itemprop" "image"
       ) }}
     {{ end }}
   </article>

--- a/layouts/_partials/persons/partials/person.html
+++ b/layouts/_partials/persons/partials/person.html
@@ -2,6 +2,8 @@
 {{ $class := partial "persons/partials/person/helper/GetClass" . }}
 <li>
   <article class="{{ $class }}" itemscope itemtype="https://schema.org/Person">
+    <meta itemprop="url" content="{{ .person.Permalink }}">
+    <meta itemprop="image" content="{{ .person.Params.image }}">
     <div class="description">
       {{ partial "persons/partials/person/name.html" (dict
         "person" .person

--- a/layouts/_partials/persons/partials/person.html
+++ b/layouts/_partials/persons/partials/person.html
@@ -4,28 +4,13 @@
   <article class="{{ $class }}" itemscope itemtype="https://schema.org/Person">
     <meta itemprop="url" content="{{ .person.Permalink }}">
     <meta itemprop="image" content="{{ .person.Params.image }}">
-    <div class="description">
-      {{ partial "persons/partials/person/name.html" (dict
+      {{ partial "persons/partials/person/description.html" (dict
         "person" .person
         "options" $options
+        "role" .role
         "heading_level" .heading_level
+        "layout" .layout
       ) }}
-      {{ if $options.summary }}
-        {{ partial "persons/partials/person/summary.html" (dict
-          "person" .person
-          "role" .role
-        ) }}
-      {{ end }}
-      {{ if $options.contact }}
-        {{ partial "persons/partials/person/contact.html" .person }}
-      {{ end }}
-      {{ if and $options.link (eq .layout "large") }}
-        {{ partial "persons/partials/person/more.html" .person }}
-      {{ end }}
-      {{ if $options.cohorts }}
-        {{ partial "persons/partials/person/cohorts.html" .person.Params.cohorts }}
-      {{ end }}
-    </div>
     {{ if $options.image }}
       {{ partial "persons/partials/person/avatar.html" (dict
         "person" .person

--- a/layouts/_partials/persons/partials/person/avatar.html
+++ b/layouts/_partials/persons/partials/person/avatar.html
@@ -4,6 +4,7 @@
     {{ partial "commons/image.html" (dict
       "image" .person.Params.image
       "sizes" $image_sizes
+      "itemprop" .itemprop
     ) }}
   {{ end }}
 </div>

--- a/layouts/_partials/persons/partials/person/avatar.html
+++ b/layouts/_partials/persons/partials/person/avatar.html
@@ -1,5 +1,5 @@
 {{ $image_sizes := .sizes | default site.Params.image_sizes.sections.persons.item }}
-<div class="avatar" itemprop="image">
+<div class="avatar">
   {{ if .person.Params.image }}
     {{ partial "commons/image.html" (dict
       "image" .person.Params.image

--- a/layouts/_partials/persons/partials/person/description.html
+++ b/layouts/_partials/persons/partials/person/description.html
@@ -1,0 +1,22 @@
+<div class="description">
+  {{ partial "persons/partials/person/name.html" (dict
+    "person" .person
+    "options" .options
+    "heading_level" .heading_level
+  ) }}
+  {{ if .options.summary }}
+    {{ partial "persons/partials/person/summary.html" (dict
+      "person" .person
+      "role" .role
+    ) }}
+  {{ end }}
+  {{ if .options.contact }}
+    {{ partial "persons/partials/person/contact.html" .person }}
+  {{ end }}
+  {{ if and .options.link (eq .layout "large") }}
+    {{ partial "persons/partials/person/more.html" .person }}
+  {{ end }}
+  {{ if .options.cohorts }}
+    {{ partial "persons/partials/person/cohorts.html" .person.Params.cohorts }}
+  {{ end }}
+</div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Plusieurs problèmes : 
- Dans `_partials/papers/single/authors.html`, on avait la déclaration du schema d'une personne avec des metadata, mais `_partials/persons/partials/person.html` fait déjà le schema inline ;
- `person.html` génère un `li` mais `authors.html` ne déclare aucune `ul`

En conséquence, on se retrouve avec une puce depuis le retrait des `@include list-reset` : 
<img width="1219" height="600" alt="Capture d’écran 2026-06-24 à 17 33 09" src="https://github.com/user-attachments/assets/b5c431a3-939b-42ca-8128-1dc25db0116e" />

On enlève donc les metadata de `authors` et on remplace la `div.author` par un `ul`, le schema se fait bien. On ajoute ensuite les métadonnées manquantes à `person.html`, cette fois directement dans deux balises meta.

(Pas certaine que ce soit le meilleur endroit pour mettre ces meta)
.
## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site example

`http://localhost:1313/fr/blocks/blocs-de-liste/organigramme/
`
## URL de test du site example journal

`http://localhost:1313/papiers/2022-02-10-qualite-front-aaa/`

## Screenshots

<img width="1676" height="895" alt="Capture d’écran 2026-06-24 à 17 43 46" src="https://github.com/user-attachments/assets/8759985a-f783-4a95-8990-2c9f731d9e58" />