### PR TITLE
Metas : retrait du bouton de partage du hero des projets

### DIFF
--- a/assets/sass/_theme/configuration/sections.sass
+++ b/assets/sass/_theme/configuration/sections.sass
@@ -13,10 +13,6 @@ $persons-avatar-background-color: var(--color-background-alt) !default
 // Organization
 $organization-background-color: $color-background-alt !default // Use sass variable color-background To avoid dark logo on darkmode background-alt color
 
-// Project
-$project-infos-color-text: $color-text !default
-$project-infos-color-text-alt: $color-text-alt !default
-
 // Program
 $program-essential-font-size: $meta-size !default
 $program-essential-font-size-desktop: $meta-size-desktop !default

--- a/assets/sass/_theme/sections/projects.sass
+++ b/assets/sass/_theme/sections/projects.sass
@@ -151,52 +151,9 @@
                     width: columns(7)
 
 .projects__page
-    .hero
-        .content
-            align-items: stretch
-        .hero-text
-            align-items: start
-            display: flex
-            flex-direction: column
-            gap: $spacing-3
-        .project-infos
-            --color-text: #{$project-infos-color-text}
-            --color-text-alt: #{$project-infos-color-text-alt}
-            @include meta
-            display: flex
-            gap: $spacing-3
-            > ul
-                display: flex
-                column-gap: $spacing-3
-                flex-wrap: wrap
-                li
-                    white-space: nowrap
-    @include media-breakpoint-up(sm)
-        .hero
-            .project-infos
-                width: columns(8)
-    @include media-breakpoint-up(md)
-        .hero
-            .project-infos
-                width: columns(6)
-            .dropdown-share
-                button
-                    width: columns(2)
     @include media-breakpoint-up(desktop)
         .hero
-            .content
-                align-items: stretch
-            .project-infos
-                width: columns(4)
             figure
                 width: columns(6)
             .hero-text
-                gap: $spacing-3
                 width: columns(6)
-                // Safe space for dropdown share button wich is in a absolute position
-                position: relative
-                padding-bottom: calc(#{$spacing-5} + #{$spacing-2}) 
-            .dropdown-share
-                position: absolute
-                bottom: 0
-                right: 0

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -475,6 +475,7 @@ params:
     single:
       meta:
         options:
+          share: true
           year: true
       navigation:
         reversed: false

--- a/layouts/_partials/projects/single/hero.html
+++ b/layouts/_partials/projects/single/hero.html
@@ -6,5 +6,4 @@
   "sizes" site.Params.image_sizes.sections.projects.hero_single
   "meta" ( partial "projects/single/meta.html" . )
   "context" .
-  "share" $share
 ) }}


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [X] Rangement

## Description

- On supprime l'appel du share dans le hero des projets
- On supprime le style relatif au `post-infos`, qui n'existe plus -> quid des variables `$project-infos-color-text`, maintenant qu'on a homogénéisé les meta ? (je les ai supprimées ici)
- On supprime le style du hero permettant au bouton d'être en absolute, ce qui permet de revenir aux espacements des autres hero

Faut-il mettre le share à true par défaut dans les projets ?

NB : ça fait pas mal de lignes supprimées côté sass, à voir si je suis allée trop loin !

## Niveau d'incidence

- [ ] Incidence faible 😌
- [X] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

http://localhost:1313/fr/projets/2025-ceci-est-un-projet/

## URL de test du site (optionnel)



## Screenshots
<img width="1918" height="898" alt="Capture d’écran 2026-06-26 à 09 34 05" src="https://github.com/user-attachments/assets/7bdd18d6-7673-4e9b-b210-f0623aa04013" />
<img width="1915" height="899" alt="Capture d’écran 2026-06-26 à 09 34 44" src="https://github.com/user-attachments/assets/5648cffc-ff6d-4a95-afb7-d3f505938a4f" />

## Sites à vérifier
- Beaux Arts
- Communication publique (revue)
- CYU (variable `$project-infos-*`)

https://github.com/search?q=org%3Aosunyorg+.dropdown-share&type=code&p=1