### PR TITLE
Bloc définitions : affichage des listes

### DIFF
--- a/assets/sass/_theme/blocks/definitions.sass
+++ b/assets/sass/_theme/blocks/definitions.sass
@@ -23,7 +23,7 @@
             font-size: $block-definition-font-size
             @include media-breakpoint-up(desktop)
                 font-size: $block-definition-font-size-desktop
-        p
+        p, ul
             margin-block-start: 0
             margin-block-end: $spacing-3
         &::after

--- a/assets/sass/_theme/blocks/definitions.sass
+++ b/assets/sass/_theme/blocks/definitions.sass
@@ -19,13 +19,12 @@
             &:hover
                 color: $block-definition-color-hovered
         summary,
-        p
+        .definition-content *
             font-size: $block-definition-font-size
             @include media-breakpoint-up(desktop)
                 font-size: $block-definition-font-size-desktop
-        p, ul
-            margin-block-start: 0
-            margin-block-end: $spacing-3
+        .definition-content
+            padding-bottom: $spacing-3
         &::after
             content: ""
             border-bottom: var(--border-width) solid $block-definition-border-color

--- a/layouts/_partials/blocks/templates/definitions.html
+++ b/layouts/_partials/blocks/templates/definitions.html
@@ -13,7 +13,9 @@
             {{ $id := printf "block-%s-element-%d" $html_id $index }}
             <details id="{{ $id }}" class="definition" itemscope itemtype="https://schema.org/DefinedTerm">
               <summary itemprop="name" aria-controls="{{ $id }}" aria-expanded="false">{{ $element.title | safeHTML }}</summary>
-              <div itemprop="description" class="definition-content rich-text">{{ safeHTML $element.description }}</div>
+              {{ with $element.description }}
+                <div itemprop="description" class="definition-content rich-text">{{ safeHTML . }}</div>
+              {{ end }}
             </details>
           {{ end }}
         </div>

--- a/layouts/_partials/blocks/templates/definitions.html
+++ b/layouts/_partials/blocks/templates/definitions.html
@@ -13,7 +13,7 @@
             {{ $id := printf "block-%s-element-%d" $html_id $index }}
             <details id="{{ $id }}" class="definition" itemscope itemtype="https://schema.org/DefinedTerm">
               <summary itemprop="name" aria-controls="{{ $id }}" aria-expanded="false">{{ $element.title | safeHTML }}</summary>
-              <div itemprop="description" class="definition-content">{{ safeHTML $element.description }}</div>
+              <div itemprop="description" class="definition-content rich-text">{{ safeHTML $element.description }}</div>
             </details>
           {{ end }}
         </div>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Les listes ne sont pas prises en compte dans les définitions, car ce n'est pas un `.rich-text` :
<img width="915" height="930" alt="image" src="https://github.com/user-attachments/assets/52c97ac6-506f-484d-bb4d-51282f1b2088" />

(la liste est à la fin de la définition)

On ajoute aussi la marge à la suite de la liste.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test sur example.osuny.org

`https://example.osuny.org/fr/blocks/blocks-techniques/definitions/#block-11-element-1`

## URL de test du site PdP Centre pour la poésie

`http://localhost:1314/reponses-a-vos-questions/faq-printemps/`

## Screenshots
<img width="926" height="953" alt="Capture d’écran 2026-07-01 à 15 26 16" src="https://github.com/user-attachments/assets/687a564a-5391-4042-9072-8e2c879f1a78" />