### PR TITLE
Ajout d'une configuration pour la meta `theme-color`

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -25,6 +25,10 @@ params:
   debug:
     active: false
     productionUrl: ""
+  head:
+    meta:
+      theme:
+        color: "#ffffff"
   keycdn:
     quality:
       default: 80

--- a/layouts/_partials/head/meta/app.html
+++ b/layouts/_partials/head/meta/app.html
@@ -1,6 +1,6 @@
 <!-- App -->
 <meta name="apple-mobile-web-app-title" content="{{ site.Title }}">
-<meta name="apple-mobile-web-app-status-bar-style" content="#ffffff">
+<meta name="apple-mobile-web-app-status-bar-style" content="{{ site.Params.head.meta.theme.color }}">
 <meta name="application-name" content="{{ site.Title }}">
-<meta name="msapplication-TileColor" content="#ffffff">
-<meta name="theme-color" content="#ffffff">
+<meta name="msapplication-TileColor" content="{{ site.Params.head.meta.theme.color }}">
+<meta name="theme-color" content="{{ site.Params.head.meta.theme.color }}">


### PR DESCRIPTION
## Type

- [x] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

```
params:
  head:
    meta:
      theme:
        color: "#f1efe9"
```

```
<meta name="theme-color" content="{{ site.Params.head.meta.theme.color }}">
```

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

