### PR TITLE
Retirer le `text-decoration` des listes de formations dans les diplômes

### DIFF
--- a/assets/sass/_theme/sections/diplomas.sass
+++ b/assets/sass/_theme/sections/diplomas.sass
@@ -24,6 +24,7 @@ ul.diplomas
             > li
                 a
                     @include h3
+                    text-decoration: none
             li
                 display: block
                 border-bottom: 0


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement


## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱
