### PR TITLE
[A11Y] Pagefind : résolution du bloquage au lecteur d'écran

### DIFF
--- a/layouts/_partials/commons/search/modal.html
+++ b/layouts/_partials/commons/search/modal.html
@@ -5,23 +5,21 @@
       <pagefind-modal-header>
         <pagefind-input class="pf-input"></pagefind-input>
       </pagefind-modal-header>
-      <pagefind-modal-body>
-        <div class="pf-modal-content">
-          <div class="pf-modal-aside">
-            <div class="pf-modal-aside-content">
-              <pagefind-summary></pagefind-summary>
-              <pagefind-filter-pane class="pf-filter-pane-container pf-filter-pane-container--desktop" expanded auto-open-threshold="0" label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
-              <pagefind-filter-pane class="pf-filter-pane-container pf-filter-pane-container--mobile" auto-open-threshold="0" label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
-            </div>
+      <div class="pf-modal-content">
+        <div class="pf-modal-aside">
+          <div class="pf-modal-aside-content">
+            <pagefind-summary aria-atomic="true" aria-live="polite"></pagefind-summary>
+            <pagefind-filter-pane class="pf-filter-pane-container pf-filter-pane-container--desktop" expanded auto-open-threshold="0" label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
+            <pagefind-filter-pane class="pf-filter-pane-container pf-filter-pane-container--mobile" auto-open-threshold="0" label="{{ i18n "commons.search.filters" }}"></pagefind-filter-pane>
           </div>
-          <pagefind-results
-            show-images
-            hide-sub-results="true"
-            class="pf-modal-results"
-            max-results="{{ site.Params.search.max_results }}">
-          </pagefind-results>
         </div>
-      </pagefind-modal-body>
+        <pagefind-results
+          show-images
+          hide-sub-results="true"
+          class="pf-modal-results"
+          max-results="{{ site.Params.search.max_results }}">
+        </pagefind-results>
+      </div>
       {{ partial "commons/search/hooks/before-modal-end.html" . }}
     </div>
   </pagefind-modal>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [x] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Le lecteur d'écran était bloqué par la balise `<pagefind-body>`, l'empêchant d'accéder aux filtres et aux résultats. C'est un problème inhérent à pagefind. Cela empêche la validation du critère 12.9 du RGAA. L'enlever ne change rien à l'affichage et au bon fonctionnement de la recherche.

On en profite pour rendre la restitution du compte des résultats dynamique, pour que cela se mette à jour avec la saisie des filtres.

## Niveau d'incidence

- [x] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1577