### PR TITLE
[A11Y] Ajout d'un lien vers la table des matières aux liens d'accès rapide

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -91,6 +91,7 @@ commons:
     menu_lang: Display language menu (English is currently selected)
     search: Go to search
     shortcut_navigation: Navigation Links
+    table_of_contents: Go to table of contents
     transcription: Transcription
     map_transcription : Transcription
     credits: "Rights reserved: "

--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -87,6 +87,7 @@ commons:
     menu_lang: Accéder au menu des langues (actuellement Français)
     search: Accéder à la recherche
     shortcut_navigation: Navigation d'accès rapide
+    table_of_contents: Accéder à la table des matières
     transcription: Transcription
     map_transcription : Données textuelles
     credits: "Droits réservés : "

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -85,6 +85,7 @@ commons:
     menu_lang: Acessar o menu de idiomas (atualmente Francês)
     search: Acessar a busca
     shortcut_navigation: Navegação de acesso rápido
+    table_of_contents: Aceder ao índice
     transcription: Transcrição
     credits: "Direitos reservados: "
   search:

--- a/layouts/_partials/header/accessibility.html
+++ b/layouts/_partials/header/accessibility.html
@@ -2,10 +2,12 @@
 <nav aria-label="{{ i18n "commons.accessibility.shortcut_navigation" }}" class="nav-accessibility" id="nav-accessibility">
   <ul>
     <li><a href="#main">{{ i18n "commons.accessibility.main_content" }}</a></li>
+
     {{ if .Params.design.toc.present }}
       {{ $toc_item_focus := cond .Params.design.toc.offcanvas "#toc-cta-title" "#toc-container" }}
       <li><a href="{{ $toc_item_focus }}">{{ i18n "commons.accessibility.table_of_contents" }}</a></li>
     {{ end }}
+
     {{ if site.Params.search.active }}
       {{ if not (and (in $search_positions "primary") (in $search_positions "upper-menu")) }}
         {{ if in $search_positions "fixed" }}

--- a/layouts/_partials/header/accessibility.html
+++ b/layouts/_partials/header/accessibility.html
@@ -2,7 +2,10 @@
 <nav aria-label="{{ i18n "commons.accessibility.shortcut_navigation" }}" class="nav-accessibility" id="nav-accessibility">
   <ul>
     <li><a href="#main">{{ i18n "commons.accessibility.main_content" }}</a></li>
-
+    {{ if .Params.design.toc.present }}
+      {{ $toc_item_focus := cond .Params.design.toc.offcanvas "#toc-cta-title" "#toc-container" }}
+      <li><a href="{{ $toc_item_focus }}">{{ i18n "commons.accessibility.table_of_contents" }}</a></li>
+    {{ end }}
     {{ if site.Params.search.active }}
       {{ if not (and (in $search_positions "primary") (in $search_positions "upper-menu")) }}
         {{ if in $search_positions "fixed" }}

--- a/layouts/_partials/toc/container.html
+++ b/layouts/_partials/toc/container.html
@@ -5,7 +5,7 @@
   {{ if $with_cta }}
     {{ partial "toc/cta.html" . }}
   {{ end }}
-  <div class="toc-container" aria-hidden="false">
+  <div class="toc-container" id="toc-container" aria-hidden="false">
     <div class="toc-content">
       {{/* TODO : quelle balise pour le titre du toc ? */}}
       <div id="toc-title" class="toc-title" role="heading" aria-level="2">{{ i18n "commons.toc.title" }}</div>

--- a/layouts/_partials/toc/cta.html
+++ b/layouts/_partials/toc/cta.html
@@ -1,5 +1,5 @@
 <div class="toc-cta">
-  <button  class="toc-cta-title" aria-label="{{ i18n "commons.toc.title" }}" type="button">
+  <button  class="toc-cta-title" id="toc-cta-title" aria-label="{{ i18n "commons.toc.title" }}" type="button">
     <span data-default="{{ i18n "commons.toc.title" }}">{{ i18n "commons.toc.title" }}</span>
   </button>
 </div>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -12,7 +12,7 @@
     {{ partial "head/script.html" . }}
   </head>
   <body class="{{ partial "body/helpers/GetBodyclass" . }}">
-    {{- partial "header/accessibility.html" -}}
+    {{- partial "header/accessibility.html" . -}}
     {{- partial "header/header.html" . -}}
     {{- partial "commons/alerts/list.html" }}
     <main id="main"


### PR DESCRIPTION
## Type

- [X] Nouvelle fonctionnalité
- [ ] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

- On détecte si la toc est présente, puis on cherche l'id adéquat (le bouton en pleine largeur, le container en semi largeur).
- Ajout des traductions

Pas certaine du nom de la variable `$toc_item_focus`

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1511

## URL de test sur example.osuny.org

Homepage (sans toc)
Actualité semi largeur : `http://localhost:1313/fr/actualites/2024-11-18-la-nouvelle-visionneuse-dosuny/#toc-container`
Actualité pleine largeur : `http://localhost:1313/fr/actualites/2025-04-03-le-festin-de-pierres/`