### PR TITLE
Plan du site : retrait des duplications d'événements

### DIFF
--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -4,8 +4,20 @@
     <li>
       <a href="{{ .Permalink }}">{{ .Title }}</a>
       {{ $events := where .RegularPagesRecursive "Params.dates.archive" false }}
+
+      {{ $events_slugs := slice }}
+      {{ $unique_events := slice }}
+
+      {{ range $events }}
+        {{ $slug := .Params.slug }}
+        {{ if not (in $events_slugs $slug) }}
+          {{ $events_slugs = $events_slugs | append $slug }}
+          {{ $unique_events = $unique_events | append . }}
+        {{ end }}
+      {{ end }}
+
       {{ partial "sitemap/sections/children.html" (dict 
-        "items" $events
+        "items" $unique_events
         "type" "events"
       ) }}
     </li>

--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -9,9 +9,9 @@
       {{ $unique_events := slice }}
 
       {{ range $events }}
-        {{ $slug := .Params.slug }}
-        {{ if not (in $events_slugs $slug) }}
-          {{ $events_slugs = $events_slugs | append $slug }}
+        {{ $event_slug := .Params.slug }}
+        {{ if not (in $events_slugs $event_slug) }}
+          {{ $events_slugs = $events_slugs | append $event_slug }}
           {{ $unique_events = $unique_events | append . }}
         {{ end }}
       {{ end }}

--- a/layouts/_partials/sitemap/sections/events.html
+++ b/layouts/_partials/sitemap/sections/events.html
@@ -5,21 +5,15 @@
       <a href="{{ .Permalink }}">{{ .Title }}</a>
       {{ $events := where .RegularPagesRecursive "Params.dates.archive" false }}
 
-      {{ $events_slugs := slice }}
-      {{ $unique_events := slice }}
-
-      {{ range $events }}
-        {{ $event_slug := .Params.slug }}
-        {{ if not (in $events_slugs $event_slug) }}
-          {{ $events_slugs = $events_slugs | append $event_slug }}
-          {{ $unique_events = $unique_events | append . }}
-        {{ end }}
+      {{/*  Group by slug to avoid duplication of recurring events and parents events with multiple dates  */}}
+      {{ range $events.GroupByParam "slug" }}
+        {{/*  Get only the first event of the group as the group contains duplicated events */}}
+        {{ $event := .Pages | first 1 }}
+        {{ partial "sitemap/sections/children.html" (dict 
+          "items" $event
+          "type" "events"
+        ) }}
       {{ end }}
-
-      {{ partial "sitemap/sections/children.html" (dict 
-        "items" $unique_events
-        "type" "events"
-      ) }}
     </li>
   {{ end }}
 </ul>


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [ ] Bug
- [X] Ajustement
- [ ] Rangement

## Description

Les événements sont en double, triple, etc. dans le plan du site, car il y a plusieurs dates.

<img width="325" height="823" alt="Capture d’écran 2026-07-21 à 16 16 15" src="https://github.com/user-attachments/assets/d0de9c95-639e-4cb3-a3fd-ab232e0abe87" />

On se fonde ici sur le slug pour identifier les doublons : chaque événement dont le slug est déjà stocké dans une `slice` est ignoré

NB : Est-ce vraiment nécessaire ? Finalement l'info du double n'est-elle pas pertinente ?

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## Référence (ticket et/ou figma)

https://github.com/osunyorg/theme/issues/1427

## URL de test sur example.osuny.org

`http://localhost:1313/fr/plan-du-site/#events`

## Screenshots

<img width="333" height="615" alt="Capture d’écran 2026-07-21 à 16 14 39" src="https://github.com/user-attachments/assets/b4b752f3-8e3d-42e6-8bc0-efade2eb98b6" />