### PR TITLE
Projets : fix du style du hero vertical

### DIFF
--- a/assets/sass/_theme/sections/projects.sass
+++ b/assets/sass/_theme/sections/projects.sass
@@ -151,6 +151,15 @@
                     width: columns(7)
 
 .projects__page
+    .hero
+        .content
+            align-items: stretch
+        .hero-text
+            align-items: start
+            display: flex
+            flex-direction: column
+            gap: $spacing-3
+
     @include media-breakpoint-up(desktop)
         .hero
             figure


### PR DESCRIPTION
## Type

- [ ] Nouvelle fonctionnalité
- [X] Bug
- [ ] Ajustement
- [ ] Rangement

## Description

Trop de style a été enlevé dans la PR #1570 
<img width="1363" height="664" alt="image" src="https://github.com/user-attachments/assets/1663c02f-442b-4c27-9b3e-f3ede6e368be" />

ça ne se voit que sur les sites avec l'affichage vertical du texte du hero.

## Niveau d'incidence

- [X] Incidence faible 😌
- [ ] Incidence moyenne 😲
- [ ] Incidence forte 😱

## URL de test du site Diapason

`http://localhost:1313/references/2026-centre-val-de-loire-remi-vous-emmene-en-voyage/`

## Screenshots

<img width="1361" height="672" alt="Capture d’écran 2026-07-27 à 11 13 52" src="https://github.com/user-attachments/assets/064548ae-94cb-410b-8064-1d56a7ae5d05" />